### PR TITLE
Use pure functions to calc `totalContribution` & `operatorContribution`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ analyzer that uses Python 3 and hence can be installed via
 Fuzz testing may then be run by executing:
 
 ```
-echidna . --contract ServiceNodeContributionEchidnaTest --config echidna.config.yml
+make node # Run the local devnet (note: This blocks the terminal)
+echidna . --contract ServiceNodeContributionEchidnaTest --config echidna-local.config.yml
 
 # Or alternatively via the make target
 

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -33,8 +33,6 @@ contract ServiceNodeContribution is Shared {
     mapping(address => uint256)            public           contributionTimestamp;
     address[]                              public           contributorAddresses;
     uint256                                public immutable maxContributors;
-    uint256                                public           operatorContribution;
-    uint256                                public           totalContribution;
 
     // Smart Contract
     bool                                   public           finalized = false;
@@ -85,12 +83,11 @@ contract ServiceNodeContribution is Shared {
      * It can only be called once by the operator and must be done before any other contributions are made.
      */
     function contributeOperatorFunds(uint256 amount, IServiceNodeRewards.BLSSignatureParams memory _blsSignature) public onlyOperator {
-        require(operatorContribution == 0, "Operator already contributed funds");
+        require(operatorContribution() == 0, "Operator already contributed funds");
         require(!cancelled, "Node has been cancelled.");
         require(amount >= minimumContribution(), "Contribution is below minimum requirement");
-        operatorContribution = amount;
         blsSignature = _blsSignature;
-        contributeFunds(operatorContribution);
+        contributeFunds(amount);
     }
 
     /**
@@ -99,9 +96,10 @@ contract ServiceNodeContribution is Shared {
      * @param amount The amount of funds to contribute.
      */
     function contributeFunds(uint256 amount) public {
-        require(operatorContribution > 0, "Operator has not contributed funds");
+        if (msg.sender != operator)
+            require(operatorContribution() > 0, "Operator has not contributed funds");
         require(amount >= minimumContribution(), "Contribution is below the minimum requirement.");
-        require(totalContribution + amount <= stakingRequirement, "Contribution exceeds the funding goal.");
+        require(totalContribution() + amount <= stakingRequirement, "Contribution exceeds the funding goal.");
         require(!finalized, "Node has already been finalized.");
         require(!cancelled, "Node has been cancelled.");
         if (contributions[msg.sender] == 0) {
@@ -109,10 +107,9 @@ contract ServiceNodeContribution is Shared {
         }
         contributions[msg.sender] += amount;
         contributionTimestamp[msg.sender] = block.timestamp;
-        totalContribution += amount;
         SENT.safeTransferFrom(msg.sender, address(this), amount);
         emit NewContribution(msg.sender, amount);
-        if (totalContribution == stakingRequirement)
+        if (totalContribution() == stakingRequirement)
             finalizeNode();
     }
 
@@ -120,7 +117,7 @@ contract ServiceNodeContribution is Shared {
      * @notice When the contribute Funds function fills the contract this is called to call the AddBLSPublicKey function on the rewards contract and send funds to it
      */
     function finalizeNode() internal {
-        require(totalContribution == stakingRequirement, "Funding goal has not been met.");
+        require(totalContribution() == stakingRequirement, "Funding goal has not been met.");
         require(!finalized, "Node has already been finalized.");
         require(!cancelled, "Node has been cancelled.");
         finalized = true;
@@ -159,8 +156,6 @@ contract ServiceNodeContribution is Shared {
 
         // NOTE: Reset left-over contract variables
         delete contributorAddresses;
-        operatorContribution = 0;
-        totalContribution    = 0;
 
         // NOTE: Re-init the contract with the operator contribution.
         finalized = false;
@@ -212,8 +207,7 @@ contract ServiceNodeContribution is Shared {
      *
      *   1) Removing contributor from contribution mapping
      *   2) Removing their address from the contribution array
-     *   3) Updating the contribution/SENT metadata in the contract
-     *   4) Refunding the SENT amount contributed to the contributor
+     *   3) Refunding the SENT amount contributed to the contributor
      *
      * @return The amount of SENT refunded for the given `toRemove` address. If
      * `toRemove` is not a contributor/does not exist, 0 is returned as the
@@ -236,15 +230,6 @@ contract ServiceNodeContribution is Shared {
             }
         }
 
-        // 3) Updating the contribution/SENT metadata in the contract 
-        totalContribution -= result;
-
-        // NOTE: Handle if the operator is being removed
-        if (toRemove == operator) {
-            require(result == operatorContribution, "Refund to operator on cancel must match operator contribution");
-            operatorContribution = 0;
-        }
-
         // 4) Refunding the SENT amount contributed to the contributor
         SENT.safeTransfer(toRemove, result);
         return result;
@@ -262,9 +247,9 @@ contract ServiceNodeContribution is Shared {
      * @return The minimum contribution amount.
      */
     function minimumContribution() public view returns (uint256) {
-        if (operatorContribution == 0)
+        if (operatorContribution() == 0)
             return (stakingRequirement - 1) / 4 + 1;
-        return _minimumContribution(stakingRequirement - totalContribution, contributorAddresses.length, maxContributors);
+        return _minimumContribution(stakingRequirement - totalContribution(), contributorAddresses.length, maxContributors);
     }
 
     function _minimumContribution(uint256 contributionRemaining, uint256 numberContributors, uint256 _maxContributors) public pure returns (uint256) {
@@ -277,8 +262,28 @@ contract ServiceNodeContribution is Shared {
      * @dev This function allows unit-tests to query the length without having
      * to know the storage slot of the array size.
      */
-    function contributorAddressesLength() public view returns (uint256) {
-        uint256 result = contributorAddresses.length;
+    function contributorAddressesLength() public view returns (uint256 result) {
+        result = contributorAddresses.length;
+        return result;
+    }
+
+    /**
+     * @notice Get the contribution by the operator, defined to always be the
+     * first contribution in the contract.
+     */
+    function operatorContribution() public view returns (uint256 result) {
+        result = contributorAddresses.length > 0 ? contributions[contributorAddresses[0]] : 0;
+        return result;
+    }
+
+    /**
+     * @notice Sum up all the contributions recorded in the contributors list
+     */
+    function totalContribution() public view returns (uint256 result) {
+        for (uint256 i = 0; i < contributorAddresses.length; i++) {
+            address entry = contributorAddresses[i];
+            result += contributions[entry];
+        }
         return result;
     }
 }

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -83,7 +83,7 @@ contract ServiceNodeContribution is Shared {
      * It can only be called once by the operator and must be done before any other contributions are made.
      */
     function contributeOperatorFunds(uint256 amount, IServiceNodeRewards.BLSSignatureParams memory _blsSignature) public onlyOperator {
-        require(operatorContribution() == 0, "Operator already contributed funds");
+        require(contributorAddresses.length == 0, "Operator already contributed funds");
         require(!cancelled, "Node has been cancelled.");
         require(amount >= minimumContribution(), "Contribution is below minimum requirement");
         blsSignature = _blsSignature;
@@ -97,7 +97,7 @@ contract ServiceNodeContribution is Shared {
      */
     function contributeFunds(uint256 amount) public {
         if (msg.sender != operator)
-            require(operatorContribution() > 0, "Operator has not contributed funds");
+            require(contributorAddresses.length > 0, "Operator has not contributed funds");
         require(amount >= minimumContribution(), "Contribution is below the minimum requirement.");
         require(totalContribution() + amount <= stakingRequirement, "Contribution exceeds the funding goal.");
         require(!finalized, "Node has already been finalized.");
@@ -247,7 +247,7 @@ contract ServiceNodeContribution is Shared {
      * @return The minimum contribution amount.
      */
     function minimumContribution() public view returns (uint256) {
-        if (operatorContribution() == 0)
+        if (contributorAddresses.length == 0)
             return (stakingRequirement - 1) / 4 + 1;
         return _minimumContribution(stakingRequirement - totalContribution(), contributorAddresses.length, maxContributors);
     }

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -230,7 +230,7 @@ contract ServiceNodeContribution is Shared {
             }
         }
 
-        // 4) Refunding the SENT amount contributed to the contributor
+        // 3) Refunding the SENT amount contributed to the contributor
         SENT.safeTransfer(toRemove, result);
         return result;
     }

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -35,7 +35,6 @@ contract ServiceNodeContribution is Shared {
     uint256                                public immutable maxContributors;
     uint256                                public           operatorContribution;
     uint256                                public           totalContribution;
-    uint256                                public           numberContributors;
 
     // Smart Contract
     bool                                   public           finalized = false;
@@ -60,7 +59,7 @@ contract ServiceNodeContribution is Shared {
     /// @param _maxContributors Maximum number of contributors allowed.
     /// @param _blsPubkey - 64 bytes bls public key
     /// @param _serviceNodeParams - Service node public key, signature proving ownership of public key and fee that operator is charging
-    constructor(address _stakingRewardsContract, uint256 _maxContributors, BN256G1.G1Point memory _blsPubkey, IServiceNodeRewards.ServiceNodeParams memory _serviceNodeParams) 
+    constructor(address _stakingRewardsContract, uint256 _maxContributors, BN256G1.G1Point memory _blsPubkey, IServiceNodeRewards.ServiceNodeParams memory _serviceNodeParams)
         nzAddr(_stakingRewardsContract)
         nzUint(_maxContributors)
     {
@@ -106,7 +105,6 @@ contract ServiceNodeContribution is Shared {
         require(!finalized, "Node has already been finalized.");
         require(!cancelled, "Node has been cancelled.");
         if (contributions[msg.sender] == 0) {
-            numberContributors += 1;
             contributorAddresses.push(msg.sender);
         }
         contributions[msg.sender] += amount;
@@ -126,8 +124,8 @@ contract ServiceNodeContribution is Shared {
         require(!finalized, "Node has already been finalized.");
         require(!cancelled, "Node has been cancelled.");
         finalized = true;
-        IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](numberContributors);
-        for (uint256 i = 0; i < numberContributors; i++) {
+        IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](contributorAddresses.length);
+        for (uint256 i = 0; i < contributorAddresses.length; i++) {
             address contributorAddress = contributorAddresses[i];
             contributors[i] = IServiceNodeRewards.Contributor(contributorAddress, contributions[contributorAddress]);
         }
@@ -138,33 +136,34 @@ contract ServiceNodeContribution is Shared {
     }
 
     /**
-     * @notice Reset the contract and refund the contributions to the operator
-     * and contributors. The operator must re-initialise the contract
+     * @notice Reset the contract allowing it to be reused to re-register the
+     * pre-existing node. The service node must be removed from the rewards
+     * contract before a contract that has been reset can be refinalized.
+     *
+     * @dev Since this contract can only be called after finalisation, the SENT
+     * balance of this contract will have been transferred to the rewards
+     * contract and hence no refunding of balances is necessary.
+     *
+     * Once finalised, any refunding that has to occur will need to be done via
+     * the rewards contract.
+     *
      * @param amount The amount of funds the operator is to contribute.
      */
     function resetContract(uint256 amount) external onlyOperator {
-        require(finalized, "Contract has not been finalized yet.");
-
-        // NOTE: Remove and refund all contributors (including the operator)
-        for (uint256 index = 0; index < numberContributors; index++) {
-            // NOTE: We return the contributions in reverse order (due to
-            // swap-and-pop pattern) for more predictability in return sequence.
-            uint256 reverseIndex = numberContributors - (index + 1);
-            address toRemove     = contributorAddresses[reverseIndex];
-            removeAndRefundContributor(toRemove);
+        require(finalized, "You cannot reset a contract that hasn't been finalised yet");
+        // NOTE: Zero out all addresses in `contributions`
+        for (uint256 i = 0; i < contributorAddresses.length; i++) {
+            address toRemove        = contributorAddresses[i];
+            contributions[toRemove] = 0;
         }
 
         // NOTE: Reset left-over contract variables
         delete contributorAddresses;
-        finalized = false;
-
-        // NOTE: Verify
-        require(contributorAddresses.length == 0, "There should be 0 contributors in the contract");
-        require(operatorContribution        == 0, "Operator contribution should have been refunded and zero-ed");
-        require(totalContribution           == 0, "The contribution should be zero-ed out");
-        require(numberContributors          == 0, "All contributors should have been refunded");
+        operatorContribution = 0;
+        totalContribution    = 0;
 
         // NOTE: Re-init the contract with the operator contribution.
+        finalized = false;
         contributeOperatorFunds(amount, blsSignature);
     }
 
@@ -238,8 +237,7 @@ contract ServiceNodeContribution is Shared {
         }
 
         // 3) Updating the contribution/SENT metadata in the contract 
-        numberContributors      -= 1;
-        totalContribution       -= result;
+        totalContribution -= result;
 
         // NOTE: Handle if the operator is being removed
         if (toRemove == operator) {
@@ -266,13 +264,13 @@ contract ServiceNodeContribution is Shared {
     function minimumContribution() public view returns (uint256) {
         if (operatorContribution == 0)
             return (stakingRequirement - 1) / 4 + 1;
-        return _minimumContribution(stakingRequirement - totalContribution, numberContributors, maxContributors);
+        return _minimumContribution(stakingRequirement - totalContribution, contributorAddresses.length, maxContributors);
     }
 
-    function _minimumContribution(uint256 _contributionRemaining, uint256 _numberContributors, uint256 _maxContributors) public pure returns (uint256) {
-        require(_maxContributors > _numberContributors, "Contributors exceed permitted maximum number of contributors");
-        uint256 numContributionsRemainingAvail = _maxContributors - _numberContributors;
-        return (_contributionRemaining - 1) / numContributionsRemainingAvail + 1;
+    function _minimumContribution(uint256 contributionRemaining, uint256 numberContributors, uint256 _maxContributors) public pure returns (uint256) {
+        require(_maxContributors > numberContributors, "Contributors exceed permitted maximum number of contributors");
+        uint256 numContributionsRemainingAvail = _maxContributors - numberContributors;
+        return (contributionRemaining - 1) / numContributionsRemainingAvail + 1;
     }
 
     /**

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -247,8 +247,8 @@ contract ServiceNodeContribution is Shared {
     function cancelNode() public onlyOperator {
         require(!finalized, "Cannot cancel a finalized node.");
         require(!cancelled, "Node has already been cancelled.");
-        removeAndRefundContributor(msg.sender);
         cancelled = true;
+        removeAndRefundContributor(msg.sender);
         emit Cancelled(serviceNodeParams.serviceNodePubkey);
     }
 

--- a/contracts/test/ServiceNodeContributionEchidnaTest.sol
+++ b/contracts/test/ServiceNodeContributionEchidnaTest.sol
@@ -72,7 +72,7 @@ contract ServiceNodeContributionEchidnaTest {
     //                                                          //
     //////////////////////////////////////////////////////////////
     function echidna_prop_max_contributor_limit() public view returns (bool) {
-        bool result = snContribution.contributorAddressesLength() < snContribution.maxContributors();
+        bool result = snContribution.contributorAddressesLength() <= snContribution.maxContributors();
         assert(result);
         return result;
     }

--- a/test/unit-js/ServiceNodeContributionTest.js
+++ b/test/unit-js/ServiceNodeContributionTest.js
@@ -204,6 +204,10 @@ describe("ServiceNodeContribution Contract Tests", function () {
                     const totalContribution          = await serviceNodeContribution.totalContribution();
                     const contributorAddressesLength = await serviceNodeContribution.contributorAddressesLength();
 
+                    // NOTE: Advance time
+                    await network.provider.send("evm_increaseTime", [60 * 60 * 24]);
+                    await network.provider.send("evm_mine");
+
                     // NOTE: Withdraw stake
                     await serviceNodeContribution.connect(contributor1).withdrawStake();
 

--- a/test/unit-js/ServiceNodeContributionTest.js
+++ b/test/unit-js/ServiceNodeContributionTest.js
@@ -91,7 +91,7 @@ describe("ServiceNodeContribution Contract Tests", function () {
                                                       .cancelNode()).to
                                                                     .emit(serviceNodeContribution, "Cancelled");
 
-            expect(await serviceNodeContribution.numberContributors()).to.equal(0);
+            expect(await serviceNodeContribution.contributorAddressesLength()).to.equal(0);
             expect(await serviceNodeContribution.totalContribution()).to.equal(0);
             expect(await serviceNodeContribution.operatorContribution()).to.equal(0);
         });
@@ -129,7 +129,7 @@ describe("ServiceNodeContribution Contract Tests", function () {
                 .to.equal(minContribution);
             await expect(await serviceNodeContribution.totalContribution())
                 .to.equal(minContribution);
-            await expect(await serviceNodeContribution.numberContributors())
+            await expect(await serviceNodeContribution.contributorAddressesLength())
                 .to.equal(1);
         });
 
@@ -157,7 +157,7 @@ describe("ServiceNodeContribution Contract Tests", function () {
                     .to.equal(previousContribution);
                 await expect(await serviceNodeContribution.totalContribution())
                     .to.equal(previousContribution + minContribution);
-                await expect(await serviceNodeContribution.numberContributors())
+                await expect(await serviceNodeContribution.contributorAddressesLength())
                     .to.equal(2);
             });
 
@@ -192,18 +192,17 @@ describe("ServiceNodeContribution Contract Tests", function () {
                                                                                 .equal(previousContribution);
                     expect(await serviceNodeContribution.totalContribution()).to
                                                                              .equal(previousContribution + minContribution1 + minContribution2);
-                    expect(await serviceNodeContribution.numberContributors()).to
-                                                                              .equal(3);
+                    expect(await serviceNodeContribution.contributorAddressesLength()).to
+                                                                                      .equal(3);
                 });
 
                 it("Withdraw contributor 1", async function () {
                     const [owner, contributor1, contributor2] = await ethers.getSigners();
 
                     // NOTE: Collect contract initial state
-                    const contributor1Amount              = await serviceNodeContribution.contributions(contributor1);
-                    const numberContributors              = await serviceNodeContribution.numberContributors();
-                    const totalContribution               = await serviceNodeContribution.totalContribution();
-                    const contributorAddressesLength      = await serviceNodeContribution.contributorAddressesLength();
+                    const contributor1Amount         = await serviceNodeContribution.contributions(contributor1);
+                    const totalContribution          = await serviceNodeContribution.totalContribution();
+                    const contributorAddressesLength = await serviceNodeContribution.contributorAddressesLength();
 
                     // NOTE: Withdraw stake
                     await serviceNodeContribution.connect(contributor1).withdrawStake();
@@ -215,7 +214,6 @@ describe("ServiceNodeContribution Contract Tests", function () {
                     await expect(serviceNodeContribution.connect(contributor1).withdrawStake()).to.be.reverted;
 
                     // NOTE: Test contract state
-                    expect(await serviceNodeContribution.numberContributors()).to.equal(numberContributors - BigInt(1));
                     expect(await serviceNodeContribution.totalContribution()).to.equal(totalContribution - contributor1Amount);
                     expect(await serviceNodeContribution.contributorAddressesLength()).to.equal(contributorAddressesLength - BigInt(1));
 

--- a/test/unit-js/ServiceNodeContributionTest.js
+++ b/test/unit-js/ServiceNodeContributionTest.js
@@ -161,27 +161,79 @@ describe("ServiceNodeContribution Contract Tests", function () {
                     .to.equal(2);
             });
 
-            it("Should be able to have multiple contributors", async function () {
-                const [owner, contributor, contributor2] = await ethers.getSigners();
-                const minContribution = await serviceNodeContribution.minimumContribution();
-                let previousContribution = await serviceNodeContribution.totalContribution();
-                await mockERC20.transfer(contributor, minContribution);
-                await mockERC20.connect(contributor).approve(serviceNodeContribution, minContribution);
-                await expect(serviceNodeContribution.connect(contributor).contributeFunds(minContribution))
-                      .to.emit(serviceNodeContribution, "NewContribution")
-                      .withArgs(await contributor.getAddress(), minContribution);
-                const minContribution2 = await serviceNodeContribution.minimumContribution();
-                await mockERC20.transfer(contributor2, minContribution2);
-                await mockERC20.connect(contributor2).approve(serviceNodeContribution, minContribution2);
-                await expect(serviceNodeContribution.connect(contributor2).contributeFunds(minContribution2))
-                      .to.emit(serviceNodeContribution, "NewContribution")
-                      .withArgs(await contributor2.getAddress(), minContribution2);
-                await expect(await serviceNodeContribution.operatorContribution())
-                    .to.equal(previousContribution);
-                await expect(await serviceNodeContribution.totalContribution())
-                    .to.equal(previousContribution + minContribution + minContribution2);
-                await expect(await serviceNodeContribution.numberContributors())
-                    .to.equal(3);
+            describe("Should be able to have multiple contributors w/min contribution", async function () {
+                beforeEach(async function () {
+                    // NOTE: Get operator contribution
+                    const [owner, contributor1, contributor2] = await ethers.getSigners();
+                    const previousContribution                = await serviceNodeContribution.totalContribution();
+
+                    // NOTE: Contributor 1 w/ minContribution()
+                    const minContribution1                   = await serviceNodeContribution.minimumContribution();
+                    await mockERC20.transfer(contributor1, minContribution1);
+                    await mockERC20.connect(contributor1).approve(serviceNodeContribution, minContribution1);
+                    await expect(serviceNodeContribution.connect(contributor1)
+                                                        .contributeFunds(minContribution1)).to
+                                                                                           .emit(serviceNodeContribution, "NewContribution")
+                                                                                           .withArgs(await contributor1.getAddress(), minContribution1);
+
+                    // NOTE: Contributor 2 w/ minContribution()
+                    const minContribution2 = await serviceNodeContribution.minimumContribution();
+                    await mockERC20.transfer(contributor2, minContribution2);
+                    await mockERC20.connect(contributor2)
+                                   .approve(serviceNodeContribution,
+                                           minContribution2);
+                    await expect(serviceNodeContribution.connect(contributor2)
+                                                        .contributeFunds(minContribution2)).to
+                                                                                           .emit(serviceNodeContribution, "NewContribution")
+                                                                                           .withArgs(await contributor2.getAddress(), minContribution2);
+
+                    // NOTE: Check contribution values
+                    expect(await serviceNodeContribution.operatorContribution()).to
+                                                                                .equal(previousContribution);
+                    expect(await serviceNodeContribution.totalContribution()).to
+                                                                             .equal(previousContribution + minContribution1 + minContribution2);
+                    expect(await serviceNodeContribution.numberContributors()).to
+                                                                              .equal(3);
+                });
+
+                it("Withdraw contributor 1", async function () {
+                    const [owner, contributor1, contributor2] = await ethers.getSigners();
+
+                    // NOTE: Collect contract initial state
+                    const contributor1Amount              = await serviceNodeContribution.contributions(contributor1);
+                    const numberContributors              = await serviceNodeContribution.numberContributors();
+                    const totalContribution               = await serviceNodeContribution.totalContribution();
+                    const contributorAddressesLength      = await serviceNodeContribution.contributorAddressesLength();
+
+                    // NOTE: Withdraw stake
+                    await serviceNodeContribution.connect(contributor1).withdrawStake();
+
+                    // NOTE: Test stake is withdrawn to contributor
+                    expect(await mockERC20.balanceOf(contributor1)).to.equal(contributor1Amount);
+
+                    // NOTE: Test repeated withdraw is reverted
+                    await expect(serviceNodeContribution.connect(contributor1).withdrawStake()).to.be.reverted;
+
+                    // NOTE: Test contract state
+                    expect(await serviceNodeContribution.numberContributors()).to.equal(numberContributors - BigInt(1));
+                    expect(await serviceNodeContribution.totalContribution()).to.equal(totalContribution - contributor1Amount);
+                    expect(await serviceNodeContribution.contributorAddressesLength()).to.equal(contributorAddressesLength - BigInt(1));
+
+                    // NOTE: Query the contributor addresses in the contract
+                    const contributorArrayLengthAfter = await serviceNodeContribution.contributorAddressesLength();
+                    const contributorArrayExpected    = [BigInt(await owner.getAddress()), BigInt(await contributor2.getAddress())];
+
+                    let contributorArray              = [];
+                    for (let index = 0; index < contributorArrayLengthAfter; index++) {
+                        const address = await serviceNodeContribution.contributorAddresses(index);
+                        contributorArray.push(address);
+                    }
+
+                    // NOTE: Compare the contributor array against what we expect
+                    expect(contributorArrayExpected.length).to.equal(contributorArray.length);
+                    for (let index = 0; index < contributorArrayExpected.length; index++)
+                        expect(contributorArray[index]).to.equal(contributorArrayExpected[index]);
+                });
             });
 
             it("Should not finalise if not full", async function () {

--- a/test/unit-js/ServiceNodeContributionTest.js
+++ b/test/unit-js/ServiceNodeContributionTest.js
@@ -78,8 +78,8 @@ describe("ServiceNodeContribution Contract Tests", function () {
 
 
         it("Does not allow contributions if operator hasn't contributed", async function () {
-            const [contributor]   = await ethers.getSigners();
-            const minContribution = await serviceNodeContribution.minimumContribution();
+            const [owner, contributor] = await ethers.getSigners();
+            const minContribution      = await serviceNodeContribution.minimumContribution();
             await mockERC20.transfer(contributor, TEST_AMNT);
             await mockERC20.connect(contributor).approve(serviceNodeContributionAddress, minContribution);
             await expect(serviceNodeContribution.connect(contributor).contributeFunds(minContribution))


### PR DESCRIPTION
This goes ontop of https://github.com/oxen-io/eth-sn-contracts/pull/20

This replaces some of the variables we use to cache calculations `totalContribution` and `operatorContribution` with a function to calculate it from the state stored in the contract. This lets up skip some of the code required to update the cached variables to match the values from the contributors array/mapping.

We make a trade-off of more expensive gas operations to avoid ensuring that our cached values are correct. Running it through Remix, `totalContribution` costs around 55k gas on a contract with 10 contributors. 