### PR TITLE
Review of slither analyzer warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ analyze:
 	# vesting or contribution withdrawal delays). At most Arbitrum nodes can
 	# rewind time by up to 24 hours or, 1 hr into the future.
 	slither . \
-		--filter-paths node_modules\|contracts/test/TestModifierOnlyOperatorViaProxyContract.sol \
+		--filter-paths node_modules\|contracts/test \
 		--exclude timestamp
 
 fuzz:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ node:
 	#npx hardhat node
 	anvil
 
+analyze:
+	slither . --filter-paths node_modules
+
 fuzz:
 	echidna . --contract ServiceNodeContributionEchidnaTest --config echidna-local.config.yml
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,12 @@ node:
 	anvil
 
 analyze:
-	slither . --filter-paths node_modules
+	# NOTE: (Block) timestamp comparison warnings are ignored (typically
+	# vesting or contribution withdrawal delays). At most Arbitrum nodes can
+	# rewind time by up to 24 hours or, 1 hr into the future.
+	slither . \
+		--filter-paths node_modules\|contracts/test/TestModifierOnlyOperatorViaProxyContract.sol \
+		--exclude timestamp
 
 fuzz:
 	echidna . --contract ServiceNodeContributionEchidnaTest --config echidna-local.config.yml

--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ We run Echidna in `assertion` testing mode which allows echidna to simulate
 multiple senders (because our contracts can potentially use multiple wallets).
 `property` testing mode simulates the transactions as if they were originating
 from the smart contract which is not as useful for testing our contracts.
+
+### Slither
+
+You can run `slither` a static analyzer separately from Echidna by executing:
+
+```
+make analyze
+```

--- a/contracts/RewardRatePool.sol
+++ b/contracts/RewardRatePool.sol
@@ -52,8 +52,8 @@ contract RewardRatePool is Initializable, Ownable2StepUpgradeable {
         uint256 released         = newTotalPaidOut - totalPaidOut;
         totalPaidOut             = newTotalPaidOut;
         lastPaidOutTime          = block.timestamp;
-        SENT.safeTransfer(beneficiary, released);
         emit FundsReleased(released);
+        SENT.safeTransfer(beneficiary, released);
     }
 
     /// @notice Setter function for beneficiary, only callable by owner

--- a/contracts/SENT.sol
+++ b/contracts/SENT.sol
@@ -10,14 +10,14 @@ import "./libraries/Shared.sol";
  */
 contract SENT is ERC20, Shared {
     constructor(
-        uint256 totalSupply,
+        uint256 totalSupply_,
         address receiverGenesisAddress
     )
         ERC20("Session", "SENT")
         nzAddr(receiverGenesisAddress)
-        nzUint(totalSupply)
+        nzUint(totalSupply_)
     {
-        _mint(receiverGenesisAddress, totalSupply);
+        _mint(receiverGenesisAddress, totalSupply_);
     }
 
     function decimals() public pure override returns (uint8) {

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -148,9 +148,9 @@ contract ServiceNodeContribution is Shared {
         // NOTE: Update the amount contributed and transfer the tokens
         contributions[msg.sender] += amount;
         contributionTimestamp[msg.sender] = block.timestamp;
-        SENT.safeTransferFrom(msg.sender, address(this), amount);
-
         emit NewContribution(msg.sender, amount);
+
+        SENT.safeTransferFrom(msg.sender, address(this), amount);
 
         // NOTE: Finalize the node if the staking requirement is met
         if (totalContribution() == stakingRequirement) {
@@ -172,6 +172,8 @@ contract ServiceNodeContribution is Shared {
         // NOTE: Finalise the contract and setup the contributors for the
         // `stakingRewardsContract`
         finalized = true;
+        emit Finalized(serviceNodeParams.serviceNodePubkey);
+
         IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](contributorAddresses.length);
         uint256 arrayLength                                   = contributorAddresses.length;
         for (uint256 i = 0; i < arrayLength; i++) {
@@ -183,7 +185,6 @@ contract ServiceNodeContribution is Shared {
         // `stakingRewardsContract`
         SENT.approve(address(stakingRewardsContract), stakingRequirement);
         stakingRewardsContract.addBLSPublicKey(blsPubkey, blsSignature, serviceNodeParams, contributors);
-        emit Finalized(serviceNodeParams.serviceNodePubkey);
     }
 
     /**

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -173,7 +173,8 @@ contract ServiceNodeContribution is Shared {
         // `stakingRewardsContract`
         finalized = true;
         IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](contributorAddresses.length);
-        for (uint256 i = 0; i < contributorAddresses.length; i++) {
+        uint256 arrayLength                                   = contributorAddresses.length;
+        for (uint256 i = 0; i < arrayLength; i++) {
             address contributorAddress = contributorAddresses[i];
             contributors[i]            = IServiceNodeRewards.Contributor(contributorAddress, contributions[contributorAddress]);
         }
@@ -206,7 +207,8 @@ contract ServiceNodeContribution is Shared {
         require(finalized, "You cannot reset a contract that hasn't been finalised yet");
 
         // NOTE: Zero out all addresses in `contributions`
-        for (uint256 i = 0; i < contributorAddresses.length; i++) {
+        uint256 arrayLength = contributorAddresses.length;
+        for (uint256 i = 0; i < arrayLength; i++) {
             address toRemove        = contributorAddresses[i];
             contributions[toRemove] = 0;
         }
@@ -302,9 +304,10 @@ contract ServiceNodeContribution is Shared {
         contributions[toRemove] = 0;
 
         // 2) Removing their address from the contribution array
-        for (uint256 index = 0; index < contributorAddresses.length; index++) {
+        uint256 arrayLength = contributorAddresses.length;
+        for (uint256 index = 0; index < arrayLength; index++) {
             if (toRemove == contributorAddresses[index]) {
-                contributorAddresses[index] = contributorAddresses[contributorAddresses.length - 1];
+                contributorAddresses[index] = contributorAddresses[arrayLength - 1];
                 contributorAddresses.pop();
                 break;
             }
@@ -405,7 +408,8 @@ contract ServiceNodeContribution is Shared {
      * @notice Sum up all the contributions recorded in the contributors list
      */
     function totalContribution() public view returns (uint256 result) {
-        for (uint256 i = 0; i < contributorAddresses.length; i++) {
+        uint256 arrayLength = contributorAddresses.length;
+        for (uint256 i = 0; i < arrayLength; i++) {
             address entry  = contributorAddresses[i];
             result        += contributions[entry];
         }

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -237,7 +237,7 @@ contract ServiceNodeContribution is Shared {
         uint256 balance = token.balanceOf(address(this));
         require(balance > 0, "Contract has no balance of the specified token.");
 
-        token.transfer(operator, balance);
+        token.safeTransfer(operator, balance);
     }
 
     /**

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -204,7 +204,7 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     /// @param contributors - optional list of contributors to the service node, first is always the operator.
     function _addBLSPublicKey(BN256G1.G1Point calldata blsPubkey, BLSSignatureParams calldata blsSignature, address caller, ServiceNodeParams calldata serviceNodeParams, Contributor[] memory contributors) internal {
         if (!IsActive) revert ContractNotActive();
-        if (contributors.length > this.maxContributors()) revert MaxContributorsExceeded();
+        if (contributors.length > maxContributors()) revert MaxContributorsExceeded();
         if (contributors.length > 0) {
             uint256 totalAmount = 0;
             for (uint256 i = 0; i < contributors.length; i++) {

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -163,11 +163,13 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     /// @param claimingAddress The address claiming the rewards.
     function _claimRewards(address claimingAddress) internal {
         uint256 claimedRewards = recipients[claimingAddress].claimed;
-        uint256 totalRewards = recipients[claimingAddress].rewards;
+        uint256 totalRewards   = recipients[claimingAddress].rewards;
         uint256 amountToRedeem = totalRewards - claimedRewards;
+
         recipients[claimingAddress].claimed = totalRewards;
-        SafeERC20.safeTransfer(designatedToken, claimingAddress, amountToRedeem);
         emit RewardsClaimed(claimingAddress, amountToRedeem);
+
+        SafeERC20.safeTransfer(designatedToken, claimingAddress, amountToRedeem);
     }
 
     /// @notice Allows users to claim their rewards. Main entry point for users claiming. Should be called after first updating rewards

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -52,7 +52,6 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     function initialize(address token_, address foundationPool_, uint256 stakingRequirement_, uint256 maxContributors_, uint256 liquidatorRewardRatio_, uint256 poolShareOfLiquidationRatio_, uint256 recipientRatio_) initializer()  public {
         if (recipientRatio_ < 1) revert RecipientRewardsTooLow();
         IsActive                     = false;
-        nextServiceNodeID            = 1;
         totalNodes                   = 0;
         blsNonSignerThreshold        = 0;
         blsNonSignerThresholdMax     = 300;

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -6,7 +6,6 @@ import "./interfaces/IServiceNodeRewards.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import "./libraries/Pairing.sol";
 

--- a/contracts/interfaces/ITokenVestingNoStaking.sol
+++ b/contracts/interfaces/ITokenVestingNoStaking.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/interfaces/ITokenVestingStaking.sol
+++ b/contracts/interfaces/ITokenVestingStaking.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../interfaces/IServiceNodeRewards.sol";

--- a/contracts/libraries/BN256G2.sol
+++ b/contracts/libraries/BN256G2.sol
@@ -664,8 +664,8 @@ library BN256G2 {
         // Define the G2Point coordinates
         uint256 x1 = h;
         uint256 x2 = 0;
-        uint256 y1;
-        uint256 y2;
+        uint256 y1 = 0;
+        uint256 y2 = 0;
 
         bool foundValidPoint = false;
 

--- a/contracts/libraries/Shared.sol
+++ b/contracts/libraries/Shared.sol
@@ -9,11 +9,8 @@ pragma solidity ^0.8.20;
  */
 
 abstract contract Shared {
-    /// @dev The address used to indicate whether transfer should send native or a token
-    address internal constant _NATIVE_ADDR = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     address internal constant _ZERO_ADDR = address(0);
-    bytes32 internal constant _NULL = "";
-    uint256 internal constant _E_18 = 1e18;
+    bytes32 internal constant _NULL      = "";
 
     /// @dev    Checks that a uint isn't zero/empty
     modifier nzUint(uint256 u) {

--- a/contracts/libraries/Shared.sol
+++ b/contracts/libraries/Shared.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @title    Shared contract

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
-    uint8 d;
+    uint8 immutable d;
     constructor(string memory name_, string memory symbol_, uint8 _decimals) ERC20(name_, symbol_) {
         d = _decimals;
         _mint(msg.sender, 100000000 * (10 ** uint256(d))); // Mint 100 million tokens for testing

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -7,7 +7,7 @@ contract MockERC20 is ERC20 {
     uint8 immutable d;
     constructor(string memory name_, string memory symbol_, uint8 _decimals) ERC20(name_, symbol_) {
         d = _decimals;
-        _mint(msg.sender, 100000000 * (10 ** uint256(d))); // Mint 100 million tokens for testing
+        _mint(msg.sender, 1e8 * (10 ** uint256(d))); // Mint 100 million tokens for testing
     }
     function decimals() public view override returns (uint8) {
         return d;

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
     uint8 d;
-    constructor(string memory name, string memory symbol, uint8 _decimals) ERC20(name, symbol) {
+    constructor(string memory name_, string memory symbol_, uint8 _decimals) ERC20(name_, symbol_) {
         d = _decimals;
         _mint(msg.sender, 100000000 * (10 ** uint256(d))); // Mint 100 million tokens for testing
     }

--- a/contracts/test/MockServiceNodeRewards.sol
+++ b/contracts/test/MockServiceNodeRewards.sol
@@ -30,7 +30,7 @@ contract MockServiceNodeRewards is Ownable {
         stakingRequirement = _stakingRequirement;
     }
 
-    function maxContributors() public view returns (uint256) {
+    function maxContributors() public pure returns (uint256) {
         return _maxContributors;
     }
 

--- a/contracts/test/MockServiceNodeRewards.sol
+++ b/contracts/test/MockServiceNodeRewards.sol
@@ -18,8 +18,8 @@ contract MockServiceNodeRewards is Ownable {
 
     uint64 public nextServiceNodeID = 1;
     uint256 public totalNodes = 0;
-    uint256 public blsNonSignerThreshold = 0;
-    uint256 private _maxContributors = 10;
+    uint256 public constant blsNonSignerThreshold = 0;
+    uint256 private constant _maxContributors = 10;
     uint256 public stakingRequirement;
 
     mapping(uint64 => IServiceNodeRewards.ServiceNode) _serviceNodes;

--- a/contracts/test/MockServiceNodeRewards.sol
+++ b/contracts/test/MockServiceNodeRewards.sol
@@ -14,13 +14,13 @@ import "../libraries/Pairing.sol";
 contract MockServiceNodeRewards is Ownable {
     using SafeERC20 for IERC20;
 
-    IERC20 public designatedToken;
+    IERC20 public immutable designatedToken;
 
     uint64 public nextServiceNodeID = 1;
     uint256 public totalNodes = 0;
     uint256 public constant blsNonSignerThreshold = 0;
     uint256 private constant _maxContributors = 10;
-    uint256 public stakingRequirement;
+    uint256 public immutable stakingRequirement;
 
     mapping(uint64 => IServiceNodeRewards.ServiceNode) _serviceNodes;
     mapping(address => IServiceNodeRewards.Recipient) public recipients;

--- a/contracts/test/MockServiceNodeRewards.sol
+++ b/contracts/test/MockServiceNodeRewards.sol
@@ -41,7 +41,7 @@ contract MockServiceNodeRewards is Ownable {
 
         // Initialize the contributors array for the service node
         uint256 contributorsLength = contributors.length;
-        require(contributorsLength <= this.maxContributors(), "Exceeds maximum contributors");
+        require(contributorsLength <= maxContributors(), "Exceeds maximum contributors");
 
         for (uint256 i = 0; i < contributorsLength; i++) {
             //_serviceNodes[nextServiceNodeID].contributors[i] = contributors[i];

--- a/contracts/test/ServiceNodeContributionEchidnaTest.sol
+++ b/contracts/test/ServiceNodeContributionEchidnaTest.sol
@@ -51,9 +51,17 @@ contract ServiceNodeContributionEchidnaTest {
 
 
     constructor() {
-        snOperator = msg.sender;
-        sentToken  = new MockERC20("Session Token", "SENT", 9);
-        snRewards  = new MockServiceNodeRewards(address(sentToken), STAKING_REQUIREMENT);
+        snOperator                     = msg.sender;
+        sentToken                      = new MockERC20("Session Token", "SENT", 9);
+        snRewards                      = new MockServiceNodeRewards(address(sentToken), STAKING_REQUIREMENT);
+
+        snParams.serviceNodePubkey     = 1;
+        snParams.serviceNodeSignature1 = 2;
+        snParams.serviceNodeSignature2 = 3;
+        snParams.fee                   = 4;
+
+        blsPubkey.X                    = 5;
+        blsPubkey.Y                    = 6;
 
         snContribution = new ServiceNodeContribution(
             /*snRewards*/         address(snRewards),

--- a/contracts/test/ServiceNodeContributionEchidnaTest.sol
+++ b/contracts/test/ServiceNodeContributionEchidnaTest.sol
@@ -218,8 +218,8 @@ contract ServiceNodeContributionEchidnaTest {
         }
 
         assert(!snContribution.finalized());
-        assert(snContribution.operatorContribution() >=  0 && snContribution.operatorContribution() <= STAKING_REQUIREMENT);
-        assert(snContribution.totalContribution()    >=  0 && snContribution.totalContribution()    <= STAKING_REQUIREMENT);
+        assert(snContribution.operatorContribution() <= STAKING_REQUIREMENT);
+        assert(snContribution.totalContribution()    <= STAKING_REQUIREMENT);
 
         assert(sentToken.balanceOf(msg.sender) == balanceBeforeWithdraw + contribution);
     }

--- a/contracts/test/ServiceNodeContributionEchidnaTest.sol
+++ b/contracts/test/ServiceNodeContributionEchidnaTest.sol
@@ -41,7 +41,7 @@ contract ServiceNodeContributionEchidnaTest {
 
     // TODO: Staking requirement is currently hard-coded to value in script/deploy-local-test.js
     // TODO: Immutable variables in the testing contract causes Echidna 2.2.3 to crash
-    uint256                               public STAKING_REQUIREMENT = 100000000000;
+    uint256                               public constant STAKING_REQUIREMENT = 100000000000;
     IERC20                                public sentToken;
     MockServiceNodeRewards                public snRewards;
     ServiceNodeContribution               public snContribution;

--- a/contracts/test/ServiceNodeContributionEchidnaTest.sol
+++ b/contracts/test/ServiceNodeContributionEchidnaTest.sol
@@ -41,7 +41,7 @@ contract ServiceNodeContributionEchidnaTest {
 
     // TODO: Staking requirement is currently hard-coded to value in script/deploy-local-test.js
     // TODO: Immutable variables in the testing contract causes Echidna 2.2.3 to crash
-    uint256                               public constant STAKING_REQUIREMENT = 100000000000;
+    uint256                               public constant STAKING_REQUIREMENT = 1e11;
     IERC20                                public sentToken;
     MockServiceNodeRewards                public snRewards;
     ServiceNodeContribution               public snContribution;

--- a/contracts/test/ServiceNodeContributionEchidnaTest.sol
+++ b/contracts/test/ServiceNodeContributionEchidnaTest.sol
@@ -66,7 +66,7 @@ contract ServiceNodeContributionEchidnaTest {
 
     function mintTokensForTesting() internal {
         if (sentToken.allowance(msg.sender, address(snRewards)) <= 0) {
-            sentToken.transferFrom(address(0), msg.sender, type(uint64).max);
+            assert(sentToken.transferFrom(address(0), msg.sender, type(uint64).max));
             sentToken.approve(address(snContribution), type(uint64).max);
         }
     }
@@ -276,7 +276,7 @@ contract ServiceNodeContributionEchidnaTest {
         if (msg.sender == snOperator && snContribution.finalized() && !snContribution.cancelled()) {
             bool fundTheContract = (amount % 2 == 0); // NOTE: 50% chance of funding
             if (fundTheContract)
-                sentToken.transferFrom(address(0), address(snContribution), amount);
+                assert(sentToken.transferFrom(address(0), address(snContribution), amount));
 
             if (fundTheContract) {
                 try snContribution.rescueERC20(address(sentToken)) {

--- a/contracts/utils/TokenConverter.sol
+++ b/contracts/utils/TokenConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/utils/TokenConverter.sol
+++ b/contracts/utils/TokenConverter.sol
@@ -8,8 +8,8 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 contract TokenConverter is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    IERC20 public tokenA;
-    IERC20 public tokenB;
+    IERC20 public immutable tokenA;
+    IERC20 public immutable tokenB;
     uint256 public conversionRateNumerator;
     uint256 public conversionRateDenominator;
 

--- a/contracts/utils/TokenConverter.sol
+++ b/contracts/utils/TokenConverter.sol
@@ -37,15 +37,15 @@ contract TokenConverter is Ownable, ReentrancyGuard {
 
     function depositTokenB(uint256 _amount) external onlyOwner {
         require(_amount > 0, "Amount must be greater than 0");
-        tokenB.safeTransferFrom(msg.sender, address(this), _amount);
         emit TokenBDeposited(_amount);
+        tokenB.safeTransferFrom(msg.sender, address(this), _amount);
     }
 
     function withdrawTokenB(uint256 _amount) external onlyOwner {
         require(_amount > 0, "Amount must be greater than 0");
         require(tokenB.balanceOf(address(this)) >= _amount, "Insufficient balance");
-        tokenB.safeTransfer(msg.sender, _amount);
         emit TokenBWithdrawn(_amount);
+        tokenB.safeTransfer(msg.sender, _amount);
     }
 
     function convertTokens(uint256 _amountA) external nonReentrant {

--- a/contracts/utils/TokenConverter.sol
+++ b/contracts/utils/TokenConverter.sol
@@ -52,9 +52,9 @@ contract TokenConverter is Ownable, ReentrancyGuard {
         require(_amountA > 0, "Amount must be greater than 0");
         uint256 amountB = (_amountA * conversionRateNumerator) / conversionRateDenominator;
         require(tokenB.balanceOf(address(this)) >= amountB, "Insufficient Token B in contract");
+        emit Conversion(msg.sender, _amountA, amountB);
         tokenA.safeTransferFrom(msg.sender, address(this), _amountA);
         tokenB.safeTransfer(msg.sender, amountB);
-        emit Conversion(msg.sender, _amountA, amountB);
     }
 }
 

--- a/contracts/utils/TokenVestingNoStaking.sol
+++ b/contracts/utils/TokenVestingNoStaking.sol
@@ -96,9 +96,8 @@ contract TokenVestingNoStaking is ITokenVestingNoStaking, Shared {
 
         revoked = true;
 
-        token.safeTransfer(revoker, refund);
-
         emit TokenVestingRevoked(token, refund);
+        token.safeTransfer(revoker, refund);
     }
 
     /**

--- a/contracts/utils/TokenVestingNoStaking.sol
+++ b/contracts/utils/TokenVestingNoStaking.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../libraries/Shared.sol";
 import "../interfaces/ITokenVestingNoStaking.sol";

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -89,13 +89,20 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
      * @param blsSignature - 128 byte signature
      * @param serviceNodeParams - Service node public key, signature proving ownership of public key and fee that operator is charging
      */
-    function addBLSPublicKey(BN256G1.G1Point calldata blsPubkey, IServiceNodeRewards.BLSSignatureParams calldata blsSignature, IServiceNodeRewards.ServiceNodeParams calldata serviceNodeParams) external onlyBeneficiary notRevoked afterStart {
+    function addBLSPublicKey(BN256G1.G1Point calldata blsPubkey,
+                             IServiceNodeRewards.BLSSignatureParams calldata blsSignature,
+                             IServiceNodeRewards.ServiceNodeParams calldata serviceNodeParams) external
+        onlyBeneficiary
+        notRevoked
+        afterStart
+    {
         uint256 stakingRequirement = stakingRewardsContract.stakingRequirement();
-        uint64 serviceNodeID = stakingRewardsContract.nextServiceNodeID();
+        uint64 serviceNodeID       = stakingRewardsContract.nextServiceNodeID();
         SENT.approve(address(stakingRewardsContract), stakingRequirement);
         investorServiceNodes.push(ServiceNode(serviceNodeID, stakingRequirement));
-        IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](1);
-        contributors[0] = IServiceNodeRewards.Contributor(address(this), stakingRequirement);
+
+        // NOTE: Pass empty array, the contract will assume sender (this contract) as operator.
+        IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](0);
         stakingRewardsContract.addBLSPublicKey(blsPubkey, blsSignature, serviceNodeParams, contributors);
     }
 

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -166,16 +166,13 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
     function revoke(IERC20 token) external override onlyRevoker notRevoked {
         require(block.timestamp <= end, "Vesting: vesting expired");
 
-        uint256 balance = token.balanceOf(address(this));
-
+        uint256 balance    = token.balanceOf(address(this));
         uint256 unreleased = _releasableAmount(token);
-        uint256 refund = balance - unreleased;
-
-        revoked = true;
-
-        token.safeTransfer(revoker, refund);
+        uint256 refund     = balance - unreleased;
+        revoked            = true;
 
         emit TokenVestingRevoked(token, refund);
+        token.safeTransfer(revoker, refund);
     }
 
     /**

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -98,8 +98,8 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
     {
         uint256 stakingRequirement = stakingRewardsContract.stakingRequirement();
         uint64 serviceNodeID       = stakingRewardsContract.nextServiceNodeID();
-        SENT.approve(address(stakingRewardsContract), stakingRequirement);
         investorServiceNodes.push(ServiceNode(serviceNodeID, stakingRequirement));
+        SENT.approve(address(stakingRewardsContract), stakingRequirement);
 
         // NOTE: Pass empty array, the contract will assume sender (this contract) as operator.
         IServiceNodeRewards.Contributor[] memory contributors = new IServiceNodeRewards.Contributor[](0);

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import "../libraries/Shared.sol";
 import "../interfaces/ITokenVestingStaking.sol";

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -111,19 +111,17 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
      * @notice Gets rewards from staking and transfers to beneficiary
      */
     function claimRewards() external onlyBeneficiary notRevoked afterStart {
-        uint256 unstaked;
-
+        uint256 unstaked = 0;
         uint256 length = investorServiceNodes.length;
-
         for (uint256 i = 1; i < length + 1; i++) {
             IServiceNodeRewards.ServiceNode memory sn = stakingRewardsContract.serviceNodes(investorServiceNodes[i - 1].serviceNodeID);
             if (sn.deposit == 0) {
                 unstaked += investorServiceNodes[i - 1].deposit;
-                
+
                 // Remove service node from the array by swapping it with the last element and then popping the array
                 investorServiceNodes[i - 1] = investorServiceNodes[length - 1];
                 investorServiceNodes.pop();
-                
+
                 // Adjust loop variables since we modified the array
                 i--;
                 length--;

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -136,7 +136,7 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
 
         uint256 amount = balanceAfterClaiming > balanceBeforeClaiming ? balanceAfterClaiming - balanceBeforeClaiming: 0;
 
-        SENT.transfer(beneficiary, amount);
+        SENT.safeTransfer(beneficiary, amount);
     }
 
     /**


### PR DESCRIPTION
This is a bunch of very small tweaks that make us more compliant with standard 'coding' practices and hence easier to recognise common patterns. There didn't seem to be anything explicitly exploitable in my eyes. 

A few of the re-entrancy attacks don't seem possible because the only external calls we do are to trusted smart-contracts e.g: 

- SENT token is deployed from OpenZeppelin's ERC20 implementation with no further external calls
- Inter-contract calls to SN rewards, where SN rewards doesn't call any further external calls

A quick summary of the fixes include

- Shadowing of variables in the constructor (suffixed these declarations with a `_` to disambiguate
- Moving emit calls above external calls. This is `slither` being paranoid about the potential of re-entrancy messing up the emit order, for example emit before a SENT transfer for example .. It's a small enough of a change that I did it to quell the warnings and I guess future changes that might suddenly make us vulnerable.
- Putting the array length into a local variable just before iterating loops as a gas optimisation
- Using `SafeERC20.safeTransfer` where possible. This didn't seem like a major issue as again we use OpenZeppelin's implementation and where we use a generic token interface, these are side-effectless functions (e.g. `rescueERC20`)
- Unifying the declared solidity version to `^0.8.20` to match OpenZeppelin contracts.
- Uninitialised variables set to 0 for explicitness, and, double writes to `nextServiceNode` in the initializer
- Remove unused state variables
- Make things constant or immutable where we can
- Fixed some dodgy code in the Echidna fuzz test contract

I added a target for running `slither` in the same configuration as I did via `make analyze`.  These are the current warnings that `slither` is still reporting that I've decided not to address, either false positives, not a problem or just code suggestions that aren't critical.

```
INFO:Detectors:
Reentrancy in ServiceNodeContribution.contributeFunds(uint256) (contracts/ServiceNodeContribution.sol#129-159):
        External calls:
        - SENT.safeTransferFrom(msg.sender,address(this),amount) (contracts/ServiceNodeContribution.sol#153)
        - finalizeNode() (contracts/ServiceNodeContribution.sol#157)
                - SENT.approve(address(stakingRewardsContract),stakingRequirement) (contracts/ServiceNodeContribution.sol#186)
                - stakingRewardsContract.addBLSPublicKey(blsPubkey,blsSignature,serviceNodeParams,contributors) (contracts/ServiceNodeContribution.sol#187)
        State variables written after the call(s):
        - finalizeNode() (contracts/ServiceNodeContribution.sol#157)
                - finalized = true (contracts/ServiceNodeContribution.sol#174)
        ServiceNodeContribution.finalized (contracts/ServiceNodeContribution.sol#45) can be used in cross function reentrancies:
        - ServiceNodeContribution.cancelNode() (contracts/ServiceNodeContribution.sol#278-284)
        - ServiceNodeContribution.contributeFunds(uint256) (contracts/ServiceNodeContribution.sol#129-159)
        - ServiceNodeContribution.finalizeNode() (contracts/ServiceNodeContribution.sol#167-188)
        - ServiceNodeContribution.finalized (contracts/ServiceNodeContribution.sol#45)
        - ServiceNodeContribution.rescueERC20(address) (contracts/ServiceNodeContribution.sol#235-244)
        - ServiceNodeContribution.resetContract(uint256) (contracts/ServiceNodeContribution.sol#207-223)
        - ServiceNodeContribution.withdrawContribution() (contracts/ServiceNodeContribution.sol#254-268)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-1
```

Re-entrancy in finalizeNode doesn't seem possible here. But fixing the warning to mute it seems like it makes the code harder to read so I've decided against it.

```
INFO:Detectors:
ServiceNodeContribution.finalizeNode() (contracts/ServiceNodeContribution.sol#167-188) ignores return value by SENT.approve(address(stakingRewardsContract),stakingRequirement) (contracts/ServiceNodeContribution.sol#186)
TokenVestingStaking.addBLSPublicKey(BN256G1.G1Point,IServiceNodeRewards.BLSSignatureParams,IServiceNodeRewards.ServiceNodeParams) (contracts/utils/TokenVestingStaking.sol#92-107) ignores return value by SENT.approve(address(stakingRewardsContract),stakingRequirement) (contracts/utils/TokenVestingStaking.sol#102)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unused-return
```

Looking at OpenZeppelin's implementation of ERC20, approve can't ever return false, only true. If something bad happens it'll revert, so seems a waste of gas to wrap these with `require` or `if` check them.

```
INFO:Detectors:
ServiceNodeRewards.initialize(address,address,uint256,uint256,uint256,uint256,uint256) (contracts/ServiceNodeRewards.sol#50-79) should emit an event for:
        - _stakingRequirement = stakingRequirement_ (contracts/ServiceNodeRewards.sol#63)
        - _maxContributors = maxContributors_ (contracts/ServiceNodeRewards.sol#64)
        - _liquidatorRewardRatio = liquidatorRewardRatio_ (contracts/ServiceNodeRewards.sol#65)
        - _poolShareOfLiquidationRatio = poolShareOfLiquidationRatio_ (contracts/ServiceNodeRewards.sol#66)
        - _recipientRatio = recipientRatio_ (contracts/ServiceNodeRewards.sol#67)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#missing-events-arithmetic
```

False positive. We are using initializer as a constructor for upgradable contracts so no event emission is needed.

```
INFO:Detectors:
TokenVestingStaking.claimRewards() (contracts/utils/TokenVestingStaking.sol#120-145) has external calls inside a loop: sn = stakingRewardsContract.serviceNodes(investorServiceNodes[i - 1].serviceNodeID) (contracts/utils/TokenVestingStaking.sol#124)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation/#calls-inside-a-loop
```

We are calling to a trusted contract so no risk of revert as per the exploit they reference .

```
INFO:Detectors:
Reentrancy in ServiceNodeContribution.contributeFunds(uint256) (contracts/ServiceNodeContribution.sol#129-159):
        External calls:
        - SENT.safeTransferFrom(msg.sender,address(this),amount) (contracts/ServiceNodeContribution.sol#153)
        - finalizeNode() (contracts/ServiceNodeContribution.sol#157)
                - SENT.approve(address(stakingRewardsContract),stakingRequirement) (contracts/ServiceNodeContribution.sol#186)
                - stakingRewardsContract.addBLSPublicKey(blsPubkey,blsSignature,serviceNodeParams,contributors) (contracts/ServiceNodeContribution.sol#187)
        Event emitted after the call(s):
        - Finalized(serviceNodeParams.serviceNodePubkey) (contracts/ServiceNodeContribution.sol#175)
                - finalizeNode() (contracts/ServiceNodeContribution.sol#157)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-3
```

Similar to the first warning in this list that was emitted. Has the same problem re: solving it.

```
INFO:Detectors:
ServiceNodeRewards.serviceNodeAdd(BN256G1.G1Point) (contracts/ServiceNodeRewards.sol#374-413) has costly operations inside a loop:
        - nextServiceNodeID += 1 (contracts/ServiceNodeRewards.sol#382)
ServiceNodeRewards.serviceNodeAdd(BN256G1.G1Point) (contracts/ServiceNodeRewards.sol#374-413) has costly operations inside a loop:
        - totalNodes += 1 (contracts/ServiceNodeRewards.sol#383)
ServiceNodeRewards.serviceNodeAdd(BN256G1.G1Point) (contracts/ServiceNodeRewards.sol#374-413) has costly operations inside a loop:
        - _aggregatePubkey = pubkey (contracts/ServiceNodeRewards.sol#408)
ServiceNodeRewards.serviceNodeAdd(BN256G1.G1Point) (contracts/ServiceNodeRewards.sol#374-413) has costly operations inside a loop:
        - _aggregatePubkey = BN256G1.add(_aggregatePubkey,pubkey) (contracts/ServiceNodeRewards.sol#410)
TokenVestingStaking.claimRewards() (contracts/utils/TokenVestingStaking.sol#120-145) has costly operations inside a loop:
        - investorServiceNodes.pop() (contracts/utils/TokenVestingStaking.sol#130)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#costly-operations-inside-a-loop
```

Maybe? Needs measuring. It'd be valuable to optimise gas here since this is the most expensive operation of the contract.

```
INFO:Detectors:
BN256G1.hashToG1(uint256) (contracts/libraries/BN256G1.sol#63-65) is never used and should be removed
BN256G1.modPow(uint256,uint256,uint256) (contracts/libraries/BN256G1.sol#17-26) is never used and should be removed
BN256G1.mul(BN256G1.G1Point,uint256) (contracts/libraries/BN256G1.sol#51-61) is never used and should be removed
BN256G2.ECTwistAdd(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256) (contracts/libraries/BN256G2.sol#65-127) is never used and should be removed
BN256G2.ECTwistMul(uint256,uint256,uint256,uint256,uint256) (contracts/libraries/BN256G2.sol#138-173) is never used and should be removed
BN256G2.GetFieldModulus() (contracts/libraries/BN256G2.sol#179-181) is never used and should be removed
BN256G2.P2() (contracts/libraries/BN256G2.sol#747-755) is never used and should be removed
BN256G2._FQ2Div(uint256,uint256,uint256,uint256) (contracts/libraries/BN256G2.sol#227-233) is never used and should be removed
BN256G2._FQ2Pow(uint256,uint256,uint256) (contracts/libraries/BN256G2.sol#243-258) is never used and should be removed
BN256G2.calcField(uint256,uint256) (contracts/libraries/BN256G2.sol#738-740) is never used and should be removed
BN256G2.getWeierstrass(uint256,uint256) (contracts/libraries/BN256G2.sol#705-707) is never used and should be removed
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#dead-code
```

Library code that has functions we don't use. We could remove but it also doesn't seem like a problem to just leave the library stock-as-is.

```
INFO:Detectors:
Version constraint ^0.8.20 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)
        - VerbatimInvalidDeduplication
        - FullInlinerNonExpressionSplitArgumentEvaluationOrder
        - MissingSideEffectsOnSelectorAccess.
 It is used by:
        - node_modules/@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol#4
        - node_modules/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol#4
        - node_modules/@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol#4
        - node_modules/@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol#4
        - node_modules/@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol#4
        - node_modules/@openzeppelin/contracts/access/Ownable.sol#4
        - node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol#3
        - node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#4
        - node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol#4
        - node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol#4
        - node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol#4
        - node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#4
        - node_modules/@openzeppelin/contracts/utils/Address.sol#4
        - node_modules/@openzeppelin/contracts/utils/Context.sol#4
        - node_modules/@openzeppelin/contracts/utils/ReentrancyGuard.sol#4
        - contracts/RewardRatePool.sol#2
        - contracts/SENT.sol#2
        - contracts/ServiceNodeContribution.sol#2
        - contracts/ServiceNodeContributionFactory.sol#2
        - contracts/ServiceNodeRewards.sol#2
        - contracts/interfaces/IServiceNodeRewards.sol#2
        - contracts/interfaces/ITokenVestingNoStaking.sol#3
        - contracts/interfaces/ITokenVestingStaking.sol#3
        - contracts/libraries/BN256G1.sol#2
        - contracts/libraries/BN256G2.sol#2
        - contracts/libraries/Pairing.sol#2
        - contracts/libraries/Shared.sol#3
        - contracts/test/BN256G2EchidnaTest.sol#2
        - contracts/test/MockERC20.sol#2
        - contracts/test/MockServiceNodeRewards.sol#2
        - contracts/test/ServiceNodeContributionEchidnaTest.sol#2
        - contracts/test/TestModifierOnlyOperatorViaProxyContract.sol#2
        - contracts/utils/TokenConverter.sol#2
        - contracts/utils/TokenVestingNoStaking.sol#3
        - contracts/utils/TokenVestingStaking.sol#3
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity
```

Don't have much comment on this, I guess we can go to the latest version? How does that work with NPM modules do we jus unpin OpenZeppelin's version?

```
INFO:Detectors:
The following unused import(s) in @openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol should be removed:
        -import {IERC20Permit} from "../extensions/IERC20Permit.sol"; (node_modules/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol#7)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unused-imports

INFO:Slither:. analyzed (38 contracts with 94 detectors), 24 result(s) found
```

slither picked up some 3rd party code. We can ignore.