### PR TITLE
DRY functions in the rewards contract and revise comments

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -660,7 +660,8 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
                                        BLSSignatureParams memory blsSignature,
                                        BN256G2.G2Point memory hashToVerify) private {
         BN256G1.G1Point memory pubkey;
-        for(uint256 i = 0; i < listOfNonSigners.length; i++) {
+        uint256 listOfNonSignersLength = listOfNonSigners.length;
+        for(uint256 i = 0; i < listOfNonSignersLength; i++) {
             uint64 serviceNodeID = listOfNonSigners[i];
             pubkey               = BN256G1.add(pubkey, _serviceNodes[serviceNodeID].pubkey);
         }

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -42,13 +42,22 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     uint256 private _recipientRatio;
 
     /// @notice Constructor for the Service Node Rewards Contract
+    ///
     /// @param token_ The token used for rewards
     /// @param foundationPool_ The foundation pool for the token
     /// @param stakingRequirement_ The staking requirement for service nodes
     /// @param liquidatorRewardRatio_ The reward ratio for liquidators
     /// @param poolShareOfLiquidationRatio_ The pool share ratio during liquidation
     /// @param recipientRatio_ The recipient ratio for rewards
-    function initialize(address token_, address foundationPool_, uint256 stakingRequirement_, uint256 maxContributors_, uint256 liquidatorRewardRatio_, uint256 poolShareOfLiquidationRatio_, uint256 recipientRatio_) initializer()  public {
+    function initialize(address token_,
+                        address foundationPool_,
+                        uint256 stakingRequirement_,
+                        uint256 maxContributors_,
+                        uint256 liquidatorRewardRatio_,
+                        uint256 poolShareOfLiquidationRatio_,
+                        uint256 recipientRatio_) public
+        initializer()
+    {
         if (recipientRatio_ < 1) revert RecipientRewardsTooLow();
         isStarted                    = false;
         totalNodes                   = 0;
@@ -146,17 +155,28 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     //////////////////////////////////////////////////////////////
 
     /// CLAIMING REWARDS
-    /// This section contains all the functions necessary for a user to receive tokens from the service node network. Process is as follows:
-    /// 1) User will go to service node network and request they sign an amount that they are allowed to claim. Each node will individually sign and user will aggregate the message
-    /// 2) User will call `updateRewardsBalance` with an encoded message of the amount they are allowed to claim. This signature is checked over
-    ///    and the recipient structure is updated with the amount of tokens they are allowed to claim.
-    /// 3) User will call `claimRewards` which will pay out their balance in the recipients struct.
+    /// This section contains all the functions necessary for a user to receive
+    /// tokens from the service node network as follows. The user will:
+    ///
+    /// 1) Go to service node network and request they sign an amount that they
+    ///    are allowed to claim. Each node will individually sign the user's
+    ///    details into an aggregate signature.
+    /// 2) Call `updateRewardsBalance` with their details and the produced
+    ///    signature. This signature is verified and the user's rewards balance
+    ///    is updated.
+    /// 3) Call `claimRewards` which will pay out the unclaimed rewards to the
+    ///    user.
 
-    /// @notice Updates the rewards balance for a given recipient, requires a BLS signature from the network
-    /// @param recipientAddress The address of the recipient.
-    /// @param recipientRewards The amount of rewards the recipient is allowed to claim.
-    /// @param blsSignature - 128 byte bls proof of possession signature
-    /// @param ids An array of service node IDs that did not sign and to be excluded from aggregation.
+    /// @notice Updates the rewards balance for a given recipient. Calling this
+    /// requires a BLS signature from the network.
+    ///
+    /// @param recipientAddress Address of the recipient to update.
+    /// @param recipientRewards Amount of rewards the recipient is allowed to
+    /// claim.
+    /// @param blsSignature 128 byte BLS proof of possession signature, signed
+    /// over the tag, `recipientAddress` and `recipientRewards`.
+    /// @param ids Array of service node IDs that didn't sign the signature
+    /// and are to be excluded from verification.
     function updateRewardsBalance( address recipientAddress, uint256 recipientRewards, BLSSignatureParams calldata blsSignature, uint64[] memory ids) external
         whenNotPaused
         whenStarted
@@ -182,7 +202,8 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         emit RewardsBalanceUpdated(recipientAddress, recipientRewards, previousBalance);
     }
 
-    /// @dev Internal function to handle reward claims. Will transfer the available rewards worth of our token to claimingAddress
+    /// @dev Internal function to handle reward claims. Will transfer the
+    /// available rewards worth of our token to claimingAddress
     /// @param claimingAddress The address claiming the rewards.
     function _claimRewards(address claimingAddress) internal {
         uint256 claimedRewards = recipients[claimingAddress].claimed;
@@ -195,39 +216,68 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         SafeERC20.safeTransfer(designatedToken, claimingAddress, amountToRedeem);
     }
 
-    /// @notice Allows users to claim their rewards. Main entry point for users claiming. Should be called after first updating rewards
+    /// @notice Claim the rewards due for the active wallet invoking the claim.
     function claimRewards() public {
         _claimRewards(msg.sender);
     }
 
     /// MANAGING BLS PUBLIC KEY LIST
-    /// This section contains all the functions necessary to add and remove service nodes from the service nodes linked list.
-    /// The regular process for a new user is to call `addBLSPublicKey` with the details of their service node. The smart contract will do some verification over the bls key,
-    /// take a staked amount of SENT tokens, and then add this node to its internal public key list. Keys that are in this list will be able to participate in BLS 
-    /// signing events going forward (such as allowing the withdrawal of funds and removal of other BLS keys)
+    /// This section contains all the functions necessary to add and remove
+    /// service nodes from the service nodes linked list. The regular process
+    /// for a new user is to call `addBLSPublicKey` with the details of their
+    /// service node. The smart contract will do some verification over the bls
+    /// key, take a staked amount of SENT tokens, and then add this node to
+    /// its internal public key list. Keys that are in this list will be able to
+    /// participate in BLS signing events going forward (such as allowing the
+    /// withdrawal of funds and removal of other BLS keys)
     ///
-    /// To leave the network and get the staked amount back the user should first initate the removal of their key by calling `initiateRemoveBLSPublicKey` this function
-    /// simply notifys the network and begins a timer of 15 days which the user must wait before they can exit. Once the 15 days has passed the network will then provide a 
-    /// bls signature so the user can call `removeBLSPublicKeyWithSignature` which will remove their public key from the linked list. Once this occurs the network will then allow
-    /// the user to claim their stake back via the `updateRewards` and `claimRewards` functions.
+    /// To leave the network and get the staked amount back the user should
+    /// first initate the removal of their key by calling
+    /// `initiateRemoveBLSPublicKey` this function simply notifys the network
+    /// and begins a timer of 15 days which the user must wait before they can
+    /// exit. Once the 15 days has passed the network will then provide a bls
+    /// signature so the user can call `removeBLSPublicKeyWithSignature` which
+    /// will remove their public key from the linked list. Once this occurs the
+    /// network will then allow the user to claim their stake back via the
+    /// `updateRewards` and `claimRewards` functions.
 
-
-    /// @notice Adds a BLS public key to the list of service nodes. Requires a proof of possession BLS signature to prove user controls the public key being added
-    /// @param blsPubkey - 64 bytes of the bls public key
-    /// @param blsSignature - 128 byte bls proof of possession signature
-    /// @param serviceNodeParams - Service node public key, signature proving ownership of public key and fee that operator is charging
-    /// @param contributors - optional list of contributors to the service node, first is always the operator.
+    /// @notice Adds a BLS public key to the list of service nodes. Requires
+    /// a proof of possession BLS signature to prove user controls the public
+    /// key being added.
+    ///
+    /// @param blsPubkey 64 byte BLS public key for the service node.
+    /// @param blsSignature 128 byte BLS proof of possession signature that
+    /// proves ownership of the `blsPubkey`.
+    /// @param serviceNodeParams The service node to add including the x25519
+    /// public key and signature that proves ownership of the private component
+    /// of the public key and the desired fee the operator is charging.
+    /// @param contributors An optional list of contributors for
+    /// multi-contribution service nodes. The first contributor's information
+    /// must be set to the operator (the current interacting wallet).
+    ///
+    /// If this list of empty, it is assumed that the service node is ran in
+    /// a solo configuration under the current interacting wallet.
     function addBLSPublicKey(BN256G1.G1Point calldata blsPubkey, BLSSignatureParams calldata blsSignature, ServiceNodeParams calldata serviceNodeParams, Contributor[] calldata contributors) external whenNotPaused {
         _addBLSPublicKey(blsPubkey, blsSignature, msg.sender, serviceNodeParams, contributors);
     }
 
     /// @dev Internal function to add a BLS public key.
-    /// @param blsPubkey - 64 bytes of the bls public key
-    /// @param blsSignature - 128 byte bls proof of possession signature
-    /// @param caller - The address calling this function
-    /// @param serviceNodeParams - Service node public key, signature proving ownership of public key and fee that operator is charging
-    /// @param contributors - optional list of contributors to the service node, first is always the operator.
-    function _addBLSPublicKey(BN256G1.G1Point calldata blsPubkey, BLSSignatureParams calldata blsSignature, address caller, ServiceNodeParams calldata serviceNodeParams, Contributor[] memory contributors) internal whenStarted {
+    ///
+    /// @param blsPubkey 64 byte BLS public key for the service node.
+    /// @param blsSignature 128 byte BLS proof of possession signature that
+    /// proves ownership of the `blsPubkey`.
+    /// @param caller The address calling this function
+    /// @param serviceNodeParams Service node public key, signature proving
+    /// ownership of public key and fee that operator is charging
+    /// @param contributors An optional list of contributors to the service
+    /// node, first is always the operator.
+    function _addBLSPublicKey(BN256G1.G1Point calldata blsPubkey,
+                              BLSSignatureParams calldata blsSignature,
+                              address caller,
+                              ServiceNodeParams calldata serviceNodeParams,
+                              Contributor[] memory contributors) internal
+      whenStarted
+    {
         if (contributors.length > maxContributors()) revert MaxContributorsExceeded();
         if (contributors.length > 0) {
             uint256 totalAmount = 0;
@@ -257,25 +307,39 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     }
 
     /// @notice Validates the proof of possession for a given BLS public key.
-    /// @param pubkey - The BLS public key.
-    /// @param blsSignature - 128 byte signature
-    /// @param operator - The address of the operator running the service node
-    /// @param serviceNodePubkey - Service Nodes 32 Byte public key
-    function validateProofOfPossession(BN256G1.G1Point memory pubkey, BLSSignatureParams calldata blsSignature, address operator, uint256 serviceNodePubkey) internal {
-        BN256G2.G2Point memory Hm = BN256G2.hashToG2(BN256G2.hashToField(string(abi.encodePacked(proofOfPossessionTag, pubkey.X, pubkey.Y, operator, serviceNodePubkey))));
+    /// @param blsPubkey 64 byte BLS public key for the service node.
+    /// @param blsSignature 128 byte BLS proof of possession signature that
+    /// proves ownership of the `blsPubkey`.
+    /// @param caller The address calling the `addBLSPublicKey` function
+    /// @param serviceNodePubkey Service node's 32 byte public key.
+    function validateProofOfPossession(BN256G1.G1Point memory blsPubkey, BLSSignatureParams calldata blsSignature, address caller, uint256 serviceNodePubkey) internal {
+        bytes memory encodedMessage      = abi.encodePacked(proofOfPossessionTag, blsPubkey.X, blsPubkey.Y, caller, serviceNodePubkey);
+        BN256G2.G2Point memory Hm        = BN256G2.hashToG2(BN256G2.hashToField(string(encodedMessage)));
+
         BN256G2.G2Point memory signature = BN256G2.G2Point([blsSignature.sigs1,blsSignature.sigs0],[blsSignature.sigs3,blsSignature.sigs2]);
-        if (!Pairing.pairing2(BN256G1.P1(), signature, BN256G1.negate(pubkey), Hm)) revert InvalidBLSProofOfPossession();
+        if (!Pairing.pairing2(BN256G1.P1(), signature, BN256G1.negate(blsPubkey), Hm)) {
+            revert InvalidBLSProofOfPossession();
+        }
     }
 
-    /// @notice Initiates the removal of a BLS public key. This simply notifies the network that the node wishes to leave the network. There will be a delay before the network allows this node to exit gracefully. Should be called first and later once the network is happy for node to exis the user should call `removeBLSPublicKeyWithSignature` with a valid BLS signature returned by the network
+    /// @notice Initiates a request for the service node to leave the network by
+    /// their service node ID.
+    ///
+    /// @dev This simply notifies the network that the node wishes to leave
+    /// the network. There will be a delay before the network allows this node
+    /// to exit gracefully. Should be called first and later once the network
+    /// is happy for node to exit the user should call
+    /// `removeBLSPublicKeyWithSignature` with a valid aggregate BLS signature
+    /// returned by the network.
+    ///
     /// @param serviceNodeID The ID of the service node to be removed.
     function initiateRemoveBLSPublicKey(uint64 serviceNodeID) public whenNotPaused {
         _initiateRemoveBLSPublicKey(serviceNodeID, msg.sender);
     }
 
-    /// @notice Initiates the removal of a BLS public key.
-    /// @param serviceNodeID The ID of the service node.
-    /// @param caller The address of a contributor associated with the service node.
+    /// @param serviceNodeID The ID of the service node to be removed.
+    /// @param caller The address of a contributor associated with the service
+    /// node that is initiating the removal.
     function _initiateRemoveBLSPublicKey(uint64 serviceNodeID, address caller) internal whenStarted {
         bool isContributor = false;
         for (uint256 i = 0; i < _serviceNodes[serviceNodeID].contributors.length; i++) {
@@ -291,11 +355,21 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         emit ServiceNodeRemovalRequest(serviceNodeID, caller, _serviceNodes[serviceNodeID].pubkey);
     }
 
-    /// @notice Removes a BLS public key using an aggregated BLS signature from the network. This is the usual path for a node to exit the network. Anyone can call this function but only the user being removed will benefit from calling this. Once removed from the smart contracts list the network will release the staked amount.
-    /// @param blsPubkey - 64 bytes of the bls public key
-    /// @param timestamp - The signature creation time
-    /// @param blsSignature - 128 byte bls proof of possession signature
-    /// @param ids An array of service node IDs that did not sign and to be excluded from aggregation.
+    /// @notice Removes a BLS public key using an aggregated BLS signature from
+    /// the network.
+    ///
+    /// @dev This is the usual path for a node to exit the network.
+    /// Anyone can call this function but only the user being removed will
+    /// benefit from calling this. Once removed from the smart contracts list
+    /// the network will release the staked amount.
+    ///
+    /// @param blsPubkey 64 byte BLS public key for the service node to be
+    /// removed.
+    /// @param timestamp The signature creation time.
+    /// @param blsSignature 128 byte BLS signature that affirms that the
+    /// `blsPubkey` is to be removed.
+    /// @param ids Array of service node IDs that didn't sign the signature
+    /// and are to be excluded from verification.
     function removeBLSPublicKeyWithSignature(BN256G1.G1Point calldata blsPubkey, uint256 timestamp, BLSSignatureParams calldata blsSignature, uint64[] memory ids) external
         whenNotPaused
         whenStarted
@@ -319,17 +393,31 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         _removeBLSPublicKey(serviceNodeID, _serviceNodes[serviceNodeID].deposit);
     }
 
-    /// @notice Removes a BLS public key after a specified wait time, this can be called without the BLS signature because the node has waited significantly longer than the required wait time.
-    /// @param serviceNodeID The ID of the service node to be removed.
+    /// @notice Removes a BLS public key after the required wait time on leave
+    /// request has transpired.
+    ///
+    /// @dev This can be called without a signature because the node has
+    /// waited the duration permitted to exit the network without a signature.
+    ///
+    /// @param serviceNodeID The ID of the service node to be removed..
     function removeBLSPublicKeyAfterWaitTime(uint64 serviceNodeID) external whenNotPaused whenStarted {
         uint256 leaveRequestTimestamp = _serviceNodes[serviceNodeID].leaveRequestTimestamp;
-        if(leaveRequestTimestamp == 0) revert LeaveRequestTooEarly(serviceNodeID, leaveRequestTimestamp, block.timestamp);
+        if(leaveRequestTimestamp == 0) {
+            revert LeaveRequestTooEarly(serviceNodeID, leaveRequestTimestamp, block.timestamp);
+        }
+
         uint256 timestamp = leaveRequestTimestamp + MAX_SERVICE_NODE_REMOVAL_WAIT_TIME;
-        if(block.timestamp <= timestamp) revert LeaveRequestTooEarly(serviceNodeID, timestamp, block.timestamp);
+        if (block.timestamp <= timestamp) {
+            revert LeaveRequestTooEarly(serviceNodeID, timestamp, block.timestamp);
+        }
+
         _removeBLSPublicKey(serviceNodeID, _serviceNodes[serviceNodeID].deposit);
     }
 
-    /// @dev Internal function to remove a BLS public key. Updates the linked list to remove the node
+    /// @dev Internal function to remove a service node from the contract. This
+    /// function updates the linked-list and mapping information for the specified
+    /// `serivceNodeID`.
+    ///
     /// @param serviceNodeID The ID of the service node to be removed.
     function _removeBLSPublicKey(uint64 serviceNodeID, uint256 returnedAmount) internal {
         address         operator      = _serviceNodes[serviceNodeID].operator;
@@ -340,10 +428,22 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         emit ServiceNodeRemoval(serviceNodeID, operator, returnedAmount, pubkey);
     }
 
-    /// @notice Removes a BLS public key using a bls signature and rewards the caller for doing so. This function can be called by anyone, but requires the network to provide a valid signature to do so. The nodes will only provides this signature if the network wishes for the node to be forcably removed (ie from a dereg) without relying on the user to remove themselves.
-    /// @param blsPubkey - 64 bytes of the bls public key
-    /// @param timestamp - The signature creation time
-    /// @param blsSignature - 128 byte bls proof of possession signature
+    /// @notice Removes a service node by liquidating their node from the
+    /// network rewarding the caller for maintaining the list.
+    ///
+    /// This function can be called by anyone, but requires the network to
+    /// approve the liquidation by aggregating a valid BLS signature. The nodes
+    /// will only provide this signature if the consensus rules permit the node
+    /// to be forcibly removed (e.g. the node was deregistered by consensus in
+    /// Oxen's state-chain).
+    ///
+    /// @param blsPubkey 64 byte BLS public key for the service node to be
+    /// removed.
+    /// @param timestamp The signature creation time.
+    /// @param blsSignature 128 byte BLS signature that affirms that the
+    /// `blsPubkey` is to be liquidated.
+    /// @param ids Array of service node IDs that didn't sign the signature
+    /// and are to be excluded from verification.
     function liquidateBLSPublicKeyWithSignature(BN256G1.G1Point calldata blsPubkey, uint256 timestamp, BLSSignatureParams calldata blsSignature, uint64[] memory ids) external
         whenNotPaused
         whenStarted
@@ -356,7 +456,9 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         }
 
         ServiceNode memory node = _serviceNodes[serviceNodeID];
-        if (blsPubkey.X != node.pubkey.X || blsPubkey.Y != node.pubkey.Y) revert BLSPubkeyDoesNotMatch(serviceNodeID, blsPubkey);
+        if (blsPubkey.X != node.pubkey.X || blsPubkey.Y != node.pubkey.Y) {
+            revert BLSPubkeyDoesNotMatch(serviceNodeID, blsPubkey);
+        }
 
         // NOTE: Validate signature
         {
@@ -366,16 +468,13 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         }
 
         // Calculating how much liquidator is paid out
-        uint256 ratioSum = _poolShareOfLiquidationRatio + _liquidatorRewardRatio + _recipientRatio;
         emit ServiceNodeLiquidated(serviceNodeID, node.operator, node.pubkey);
-        uint256 deposit = node.deposit;
-
+        uint256 ratioSum         = _poolShareOfLiquidationRatio + _liquidatorRewardRatio + _recipientRatio;
+        uint256 deposit          = node.deposit;
         uint256 liquidatorAmount = deposit * _liquidatorRewardRatio / ratioSum;
-        /*uint256 poolAmount = deposit * ceilDiv(_poolShareOfLiquidationRatio, ratioSum;*/
-        uint256 poolAmount = deposit * _poolShareOfLiquidationRatio == 0 ? 0 : (_poolShareOfLiquidationRatio - 1) / ratioSum + 1;
+        uint256 poolAmount       = deposit * _poolShareOfLiquidationRatio == 0 ? 0 : (_poolShareOfLiquidationRatio - 1) / ratioSum + 1;
 
         _removeBLSPublicKey(serviceNodeID, deposit - liquidatorAmount - poolAmount);
-
 
         // Transfer funds to pool and liquidator
         if (_liquidatorRewardRatio > 0)
@@ -384,12 +483,20 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
             SafeERC20.safeTransfer(designatedToken, address(foundationPool), poolAmount);
     }
 
-    /// @notice Seeds the public key list with an initial set of keys. Only should be called before the hardfork by the foundation to ensure the public key list is ready to operate.
+    /// @notice Seeds the public key list with an initial set of service nodes.
+    ///
+    /// @dev This should be called before the hardfork by the foundation to
+    /// ensure the public key list is ready to operate.
+    ///
     /// @param pkX Array of X-coordinates for the public keys.
     /// @param pkY Array of Y-coordinates for the public keys.
-    /// @param amounts Array of amounts that the service node has staked, associated with each public key.
+    /// @param amounts Array of amounts that the service node has staked,
+    /// associated with each public key.
     function seedPublicKeyList(uint256[] calldata pkX, uint256[] calldata pkY, uint256[] calldata amounts) external onlyOwner {
-        if (pkX.length != pkY.length || pkX.length != amounts.length) revert ArrayLengthMismatch();
+        if (pkX.length != pkY.length || pkX.length != amounts.length) {
+            revert ArrayLengthMismatch();
+        }
+
         for (uint256 i = 0; i < pkX.length; i++) {
             BN256G1.G1Point memory pubkey  = BN256G1.G1Point(pkX[i], pkY[i]);
             uint64 allocID                 = serviceNodeAdd(pubkey);
@@ -486,18 +593,21 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         totalNodes = serviceNodesLength();
     }
 
-    /// @notice Updates the internal threshold for how many non signers an aggregate signature can contain before being invalid
+    /// @notice Updates the internal threshold for how many non signers an
+    /// aggregate signature can contain before being invalid
     function updateBLSNonSignerThreshold() internal {
         uint256 oneThirdOfNodes = totalNodes / 3;
         blsNonSignerThreshold   = oneThirdOfNodes > blsNonSignerThresholdMax ? blsNonSignerThresholdMax : oneThirdOfNodes;
     }
 
-    /// @notice Contract begins locked and owner can start after nodes have been populated and hardfork has begun
+    /// @notice Contract begins locked and owner can start after nodes have been
+    /// populated and hardfork has begun
     function start() public onlyOwner {
         isStarted = true;
     }
 
-    /// @notice Pause will prevent new keys from being added and removed, and also the claiming of rewards
+    /// @notice Pause will prevent new keys from being added and removed, and
+    /// also the claiming of rewards
     function pause() public onlyOwner {
         _pause();
     }
@@ -623,7 +733,10 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         return _aggregatePubkey;
     }
 
-    /// @dev Builds a tag string using a base tag and contract-specific information. This is used when signing messages to prevent reuse of signatures across different domains (chains/functions/contracts)
+    /// @dev Builds a tag string using a base tag and contract-specific
+    /// information. This is used when signing messages to prevent reuse of
+    /// signatures across different domains (chains/functions/contracts)
+    ///
     /// @param baseTag The base string for the tag.
     /// @return The constructed tag string.
     function buildTag(string memory baseTag) private view returns (bytes32) {

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -45,7 +45,7 @@ interface IServiceNodeRewards {
     function blsNonSignerThreshold() external view returns (uint256);
     function designatedToken() external view returns (IERC20);
     function foundationPool() external view returns (IERC20);
-    function IsActive() external view returns (bool);
+    function isStarted() external view returns (bool);
     function liquidateTag() external view returns (bytes32);
     function liquidatorRewardRatio() external view returns (uint256);
     function maxContributors() external view returns (uint256);


### PR DESCRIPTION
Goes on-top of https://github.com/oxen-io/eth-sn-contracts/pull/27

Revised the comments to match what the code is doing, fix some typos and mistakes. DRYed some functions that had repetitive sequences and added some modifiers for some of the functionality of the contract. I've marked WIP because I have a question:

I noticed we have an `IsActive` which I've renamed to `isStarted` to match the naming of the `start()` function. But I also noticed we have a `whenNotPaused` which I believe is inherited from OpenZeppelin's `Pausable` contract.

Do these functionalities overlap, can we remove `isStarted` and defer to using pause and resuming of the contract?