### PR TITLE
Ensure latest ethyl works with repository

### DIFF
--- a/test/cpp/include/service_node_rewards/erc20_contract.hpp
+++ b/test/cpp/include/service_node_rewards/erc20_contract.hpp
@@ -8,13 +8,19 @@
 
 class ERC20Contract {
 public:
-    ERC20Contract(const std::string& contractAddress, std::shared_ptr<Provider> provider);
-
     // Function to call the 'approve' method of the ERC20 token contract
     Transaction approve(const std::string& spender, uint64_t amount);
     uint64_t balanceOf(const std::string& address);
 
-private:
+    /// Address of the ERC20 contract that must be set to the address of the
+    /// contract on the blockchain for the functions to succeed. If the contract
+    /// is not set, the functions that communicate with the provider will send
+    /// to the 0 address.
     std::string contractAddress;
-    std::shared_ptr<Provider> provider;
+
+    /// Provider must be set with an RPC client configure to allow the contract
+    /// to communicate with the blockchain. If the provider is not setup, the
+    /// functions that require a provider will throw.
+    ethyl::Provider provider;
+
 };

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -18,7 +18,7 @@ struct Recipient {
 
 struct Contributor {
     std::array<unsigned char, 20> address;
-    std::string                   amount;
+    uint64_t                      amount;
 };
 
 struct ContractServiceNode {
@@ -35,9 +35,6 @@ class ServiceNodeRewardsContract {
 public:
     // TODO: Taken from scripts/deploy-local-test.js and hardcoded
     static constexpr inline uint64_t STAKING_REQUIREMENT = 100'000'000'000;
-
-    // Constructor
-    ServiceNodeRewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);
 
     // Method for creating a transaction to add a public key
     Transaction addBLSPublicKey(const std::string& publicKey, const std::string& sig, const std::string& serviceNodePubkey, const std::string& serviceNodeSignature, uint64_t fee);
@@ -58,7 +55,14 @@ public:
     Transaction claimRewards();
     Transaction start();
 
-private:
+    /// Address of the ERC20 contract that must be set to the address of the
+    /// contract on the blockchain for the functions to succeed. If the contract
+    /// is not set, the functions that communicate with the provider will send
+    /// to the 0 address.
     std::string contractAddress;
-    std::shared_ptr<Provider> provider;
+
+    /// Provider must be set with an RPC client configure to allow the contract
+    /// to communicate with the blockchain. If the provider is not setup, the
+    /// functions that require a provider will throw.
+    ethyl::Provider provider;
 };

--- a/test/cpp/src/erc20_contract.cpp
+++ b/test/cpp/src/erc20_contract.cpp
@@ -1,15 +1,12 @@
 #include "service_node_rewards/erc20_contract.hpp"
 
 #include "service_node_rewards/ec_utils.hpp"
-
-#include <ethyl/utils.hpp>
-
-// Constructor
-ERC20Contract::ERC20Contract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider)
-    : contractAddress(_contractAddress), provider(_provider) {}
+#include "ethyl/utils.hpp"
 
 // Function to call 'approve' method of ERC20 token contract
 Transaction ERC20Contract::approve(const std::string& spender, uint64_t amount) {
+    assert(contractAddress.size());
+
     Transaction tx(contractAddress, 0, 3000000);
     std::string functionSelector = utils::getFunctionSignature("approve(address,uint256)");
 
@@ -28,7 +25,9 @@ Transaction ERC20Contract::approve(const std::string& spender, uint64_t amount) 
 
 // Function to call 'balanceOf' method of ERC20 token contract
 uint64_t ERC20Contract::balanceOf(const std::string& address) {
-    ReadCallData callData;
+    assert(contractAddress.size());
+
+    ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
 
     std::string functionSelector = utils::getFunctionSignature("balanceOf(address)");
@@ -39,7 +38,7 @@ uint64_t ERC20Contract::balanceOf(const std::string& address) {
     }
     std::string address_padded = utils::padTo32Bytes(addressOutput, utils::PaddingDirection::LEFT);
     callData.data = functionSelector + address_padded;
-    std::string result = provider->callReadFunction(callData);
+    std::string result = provider.callReadFunction(callData);
 
     // Parse the result into a uint64_t
     // Assuming the result is returned as a 32-byte hexadecimal string that fits into uint64_t

--- a/test/cpp/src/service_node_rewards_contract.cpp
+++ b/test/cpp/src/service_node_rewards_contract.cpp
@@ -1,12 +1,6 @@
 #include "service_node_rewards/service_node_rewards_contract.hpp"
-
-#include <ethyl/utils.hpp>
+#include "ethyl/utils.hpp"
 #include <nlohmann/json.hpp>
-
-#include <iostream>
-
-ServiceNodeRewardsContract::ServiceNodeRewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider)
-        : contractAddress(_contractAddress), provider(_provider) {}
 
 Transaction ServiceNodeRewardsContract::addBLSPublicKey(const std::string& publicKey, const std::string& sig, const std::string& serviceNodePubkey, const std::string& serviceNodeSignature, const uint64_t fee) {
     Transaction tx(contractAddress, 0, 3000000);
@@ -28,11 +22,11 @@ Transaction ServiceNodeRewardsContract::addBLSPublicKey(const std::string& publi
 
 ContractServiceNode ServiceNodeRewardsContract::serviceNodes(uint64_t index)
 {
-    ReadCallData callData            = {};
+    ethyl::ReadCallData callData            = {};
     std::string  indexABI            = utils::padTo32Bytes(utils::decimalToHex(index), utils::PaddingDirection::LEFT);
     callData.contractAddress         = contractAddress;
     callData.data                    = utils::getFunctionSignature("serviceNodes(uint64)") + indexABI;
-    nlohmann::json     callResult    = provider->callReadFunctionJSON(callData);
+    nlohmann::json     callResult    = provider.callReadFunctionJSON(callData);
     const std::string& callResultHex = callResult.get_ref<nlohmann::json::string_t&>();
     std::string_view   callResultIt  = utils::trimPrefix(callResultHex, "0x");
 
@@ -94,7 +88,7 @@ uint64_t ServiceNodeRewardsContract::serviceNodeIDs(const bls::PublicKey& pKey)
     std::string bytesSizeABI        = utils::padTo32Bytes(utils::decimalToHex(pKeyABI.size() / 2), utils::PaddingDirection::LEFT);
 
     // NOTE: Setup call data
-    ReadCallData callData    = {};
+    ethyl::ReadCallData callData    = {};
     callData.contractAddress = contractAddress;
 
     // NOTE: Fill in ABI
@@ -105,32 +99,32 @@ uint64_t ServiceNodeRewardsContract::serviceNodeIDs(const bls::PublicKey& pKey)
     callData.data += pKeyABI;
 
     // NOTE: Call function
-    nlohmann::json     callResult = provider->callReadFunctionJSON(callData);
+    nlohmann::json     callResult = provider.callReadFunctionJSON(callData);
     const std::string& resultHex  = callResult.get_ref<nlohmann::json::string_t&>();
     uint64_t           result     = utils::fromHexStringToUint64(resultHex);
     return result;
 }
 
 uint64_t ServiceNodeRewardsContract::serviceNodesLength() {
-    ReadCallData callData;
+    ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
     callData.data = utils::getFunctionSignature("serviceNodesLength()");
-    std::string result = provider->callReadFunction(callData);
+    std::string result = provider.callReadFunction(callData);
     return utils::fromHexStringToUint64(result);
 }
 
 std::string ServiceNodeRewardsContract::designatedToken() {
-    ReadCallData callData;
+    ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
     callData.data = utils::getFunctionSignature("designatedToken()");
-    return provider->callReadFunction(callData);
+    return provider.callReadFunction(callData);
 }
 
 std::string ServiceNodeRewardsContract::aggregatePubkeyString() {
-    ReadCallData callData    = {};
+    ethyl::ReadCallData callData    = {};
     callData.contractAddress = contractAddress;
     callData.data            = utils::getFunctionSignature("aggregatePubkey()");
-    return provider->callReadFunction(callData);
+    return provider.callReadFunction(callData);
 }
 
 bls::PublicKey ServiceNodeRewardsContract::aggregatePubkey() {
@@ -140,7 +134,7 @@ bls::PublicKey ServiceNodeRewardsContract::aggregatePubkey() {
 }
 
 Recipient ServiceNodeRewardsContract::viewRecipientData(const std::string& address) {
-    ReadCallData callData;
+    ethyl::ReadCallData callData;
     callData.contractAddress = contractAddress;
 
     std::string rewardAddressOutput = address;
@@ -149,7 +143,7 @@ Recipient ServiceNodeRewardsContract::viewRecipientData(const std::string& addre
     rewardAddressOutput = utils::padTo32Bytes(rewardAddressOutput, utils::PaddingDirection::LEFT);
     callData.data = utils::getFunctionSignature("recipients(address)") + rewardAddressOutput;
 
-    std::string result = provider->callReadFunction(callData);
+    std::string result = provider.callReadFunction(callData);
 
     // This assumes both the returned integers fit into a uint64_t but they are actually uint256 and dont have a good way of storing the 
     // full amount. In tests this will just mean that we need to keep our numbers below the 64bit max.

--- a/test/cpp/test/src/basic_ethereum.cpp
+++ b/test/cpp/test/src/basic_ethereum.cpp
@@ -9,7 +9,8 @@
 
 TEST_CASE( "Get balance from local network", "[ethereum]" ) {
     const auto& config = ethbls::get_config(ethbls::network_type::LOCAL);
-    Provider client("Local Client", std::string(config.RPC_URL));
+    ethyl::Provider client;
+    client.addClient("Local Client", std::string(config.RPC_URL));
 
     // Get the balance of the first hardhat address and make sure it has a balance
     auto balance = client.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -18,7 +19,8 @@ TEST_CASE( "Get balance from local network", "[ethereum]" ) {
 
 TEST_CASE( "Get latest contract address", "[ethereum]" ) {
     const auto& config = ethbls::get_config(ethbls::network_type::LOCAL);
-    Provider client("Local Client", std::string(config.RPC_URL));
+    ethyl::Provider client;
+    client.addClient("Local Client", std::string(config.RPC_URL));
 
     // Get the deployed contract, make sure it exists
     auto contract_address = client.getContractDeployedInLatestBlock();


### PR DESCRIPTION
re: Offline discussions, I remembered why I separated the `Provider` away and gave each contract its own instance. `Provider` wasn't thread-safe and the idea was that you just copied in the provider details into each contract of which there aren't many. In oxen-core we were have the L2 tracker threaded which was going to cause problems that it'd be better to give each of the threads their own dedicated network connection to avoid contention.

`cpr` does have this multi-session kind of functionality that we could work in eventually and allow just one provider. But it does makes things simple right now to value copy the configuration around. So I did just that here with the added benefit that ethyl doesn't have to change.