### PR TITLE
Enforce small contributor leave restriction

### DIFF
--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -16,6 +16,7 @@ interface IServiceNodeRewards {
         uint64 prev;
         address operator;
         BN256G1.G1Point pubkey;
+        uint256 addedTimestamp;
         uint256 leaveRequestTimestamp;
         uint256 deposit;
         Contributor[] contributors;


### PR DESCRIPTION
Current Oxen restricts small (<25%) contributors from initiating a service node unlock within the first 30 days of its registration.

This was a change in response to operator feedback when we were contemplating introducing small contributor spots in the first place, changing operator + three contributors to operator + nine contributors.  One of the feedback points we received from multiple shared node operators is that they were worried that this change would be quite disruptive because it meant people with very little stake could join and then quickly unlock, causing an increased operator maintenance burden for operators.  To address this, we combined the contributor spot increase with a 30-day cooldown period during which small contributors—those contributing less than 25% of the required stake—could not initiate an unlock.  (Large contributors, which implicitly includes the operator who always must contribute >= 25%, are unaffected).

This implements the restriction in the smart contract by adding an `addedTimestamp` field that we used to enforce the 30-day cooldown for small contributor leave requests.

We can't easily do this just on Oxen side for a couple of reasons:
- the leaveRequestTimestamp affects when the node can be forcibly removed
- the associated event is only emitted on the first leave request, so if we ignore it on the Oxen side for being invalid, we would never receive a later, valid event.  We could change that by allowing it to be emitted multiple times, but that would likely also require more intrusive changes in oxen and the smart contract to deal with the fallback forcible removal (which currently doesn't require a signature).