### PR TITLE
Add contributors to the seeding process

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -567,8 +567,9 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
                     "Seeded service cannot have more than 10 contributors");
 
             // NOTE: Add node to the smart contract
-            uint64 allocID                 = serviceNodeAdd(node.pubkey);
-            _serviceNodes[allocID].deposit = node.deposit;
+            uint64 allocID                  = serviceNodeAdd(node.pubkey);
+            _serviceNodes[allocID].deposit  = node.deposit;
+            _serviceNodes[allocID].operator = node.contributors[0].addr;
 
             uint256 stakedAmountSum = 0;
             for (uint256 contributorIndex = 0; contributorIndex < node.contributors.length; contributorIndex++) {

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -6,8 +6,14 @@ import "../libraries/BN256G1.sol";
 
 interface IServiceNodeRewards {
     struct Contributor {
-        address addr; // The address of the contributor
+        address addr;         // The address of the contributor
         uint256 stakedAmount; // The amount staked by the contributor
+    }
+
+    struct SeedServiceNode {
+        BN256G1.G1Point pubkey;
+        uint256 deposit;
+        Contributor[] contributors;
     }
 
     /// @notice Represents a service node in the network.
@@ -90,7 +96,7 @@ interface IServiceNodeRewards {
         BLSSignatureParams calldata blsSignature,
         uint64[] memory ids
     ) external;
-    function seedPublicKeyList(uint256[] calldata pkX, uint256[] calldata pkY, uint256[] calldata amounts) external;
+    function seedPublicKeyList(SeedServiceNode[] calldata nodes) external;
     function serviceNodesLength() external view returns (uint256 count);
     function updateServiceNodesLength() external;
     function start() external;

--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -1,6 +1,17 @@
 const { expect } = require("chai");
 const { ethers, upgrades } = require("hardhat");
 
+async function verifySeedData(contractSN, seedEntry) {
+    expect(contractSN.pubkey[0]).to.equal(BigInt(seedEntry.pubkey.X));
+    expect(contractSN.pubkey[1]).to.equal(BigInt(seedEntry.pubkey.Y));
+    expect(contractSN.deposit).to.equal(BigInt(seedEntry.deposit));
+    expect(contractSN.contributors.length).to.equal(seedEntry.contributors.length);
+    for (let contributorIndex = 0; contributorIndex < contractSN.contributors.length; contributorIndex++) {
+        expect(BigInt(contractSN.contributors[0].addr)).to.equal(BigInt(seedEntry.contributors[contributorIndex].addr));
+        expect(contractSN.contributors[0].stakedAmount).to.equal(seedEntry.contributors[contributorIndex].stakedAmount);
+    }
+}
+
 describe("ServiceNodeRewards Contract Tests", function () {
     let MockERC20;
     let mockERC20;
@@ -45,39 +56,61 @@ describe("ServiceNodeRewards Contract Tests", function () {
     describe("Seeding the public key as owner", function () {
 
         it("Should correctly seed public key list with a single item", async function () {
-            // Example values for BN256G1 X and Y coordinates (These are arbitrary 32-byte hexadecimal values)
-            let P = [
-                BigInt("0x0b5e634d0407c021e9e9dd9d03c4965810e236fef0955ab345e1d049a0438ec6"),
-                BigInt("0x1dbb7bf2b1f5340d4b5c466a0641b00cd3a9d9588c7bcad1c3158bdcc65c3332"),
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x0b5e634d0407c021e9e9dd9d03c4965810e236fef0955ab345e1d049a0438ec6",
+                        Y: "0x1dbb7bf2b1f5340d4b5c466a0641b00cd3a9d9588c7bcad1c3158bdcc65c3332",
+                    },
+                    deposit: 1000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 1000,
+                        }
+                    ]
+                },
             ];
 
-            // Convert BigInt to hex strings
-            const pkX = [P[0]];
-            const pkY = [P[1]];
-            const amounts = [1000]; // Example token amounts
-
-            await serviceNodeRewards.connect(owner).seedPublicKeyList(pkX, pkY, amounts);
-
+            await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
             expect(await serviceNodeRewards.serviceNodesLength()).to.equal(1);
             let aggregate_pubkey = await serviceNodeRewards.aggregatePubkey();
-            expect(aggregate_pubkey[0] == P[0])
-            expect(aggregate_pubkey[1] == P[1])
+            expect(aggregate_pubkey[0] == seedData[0].pubkey.X)
+            expect(aggregate_pubkey[1] == seedData[0].pubkey.Y)
+            verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
         });
 
         it("Should correctly seed public key list with multiple items", async function () {
-            // Example values for BN256G1 X and Y coordinates (These are arbitrary 32-byte hexadecimal values)
-            let P = [
-                BigInt("0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed"),
-                BigInt("0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab"),
-                BigInt("0x2ef6b73ab4486484de80681753a6a90c6a88a71f60aace9520fe6bb8bb8de34e"),
-                BigInt("0x29b8f2a87a758a89c394b121298b946dce9ada3226b5d008e54e54ddcd9e5227"),
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 2000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 2000,
+                        }
+                    ]
+                },
+                {
+                    pubkey: {
+                        X: "0x2ef6b73ab4486484de80681753a6a90c6a88a71f60aace9520fe6bb8bb8de34e",
+                        Y: "0x29b8f2a87a758a89c394b121298b946dce9ada3226b5d008e54e54ddcd9e5227",
+                    },
+                    deposit: 2000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 2000,
+                        }
+                    ]
+                },
             ];
 
-            const pkX = [P[0], P[2]];
-            const pkY = [P[1], P[3]];
-            const amounts = [1000, 2000]; // Example token amounts
-
-            await serviceNodeRewards.connect(owner).seedPublicKeyList(pkX, pkY, amounts);
+            await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
             let expected_aggregate_pubkey = [
                 BigInt("0x040a638a13320ea807115f1e7865c89c70d2d3df83e2e8c3eaea519e18b6e6b0"),
                 BigInt("0x019081a4475388be53e1088f6ec0dd79f99fc794709b9cf8b1ad401a9c4d3413"),
@@ -86,26 +119,167 @@ describe("ServiceNodeRewards Contract Tests", function () {
             expect(aggregate_pubkey[0] == expected_aggregate_pubkey[0])
             expect(aggregate_pubkey[1] == expected_aggregate_pubkey[1])
 
+            // NOTE: We know that the sentinel node is reserved at the 0th ID.
+            // Hence the 2 service nodes we added are at ID 1 and 2.
             expect(await serviceNodeRewards.serviceNodesLength()).to.equal(2);
-
+            verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
+            verifySeedData(await serviceNodeRewards.serviceNodes(2), seedData[1]);
         });
 
         it("Should fail to seed public key list with duplicate items", async function () {
-            // Example values for BN256G1 X and Y coordinates (These are arbitrary 32-byte hexadecimal values)
-            let P = [
-                BigInt("0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed"),
-                BigInt("0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab"),
-                BigInt("0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed"),
-                BigInt("0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab"),
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 1000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 1000,
+                        }
+                    ]
+                },
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 1000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 1000,
+                        }
+                    ]
+                },
             ];
 
-            const pkX = [P[0], P[2]];
-            const pkY = [P[1], P[3]];
-            const amounts = [1000, 2000]; // Example token amounts
-            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(pkX, pkY, amounts))
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData))
                 .to.be.revertedWithCustomError(serviceNodeRewards, "BLSPubkeyAlreadyExists")
         });
-        
+
+        it("Fails when sum of contributor stakes do not add up the deposit amount", async function () {
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 1000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 500,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Fails if deposit is 0", async function () {
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 0,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 1000,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Fails if the BLS pubkey is the zero key", async function () {
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        Y: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    },
+                    deposit: 1000,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: 1000,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Fails if there are no contributors", async function () {
+            const seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 1000,
+                    contributors: []
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Supports 10 contributors", async function () {
+            seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 1000,
+                    contributors: []
+                },
+            ];
+
+            const contributorCount    = 10;
+            const ethAddr             = "0x66d801a70615979d82c304b7db374d11c232db66";
+            const stakePerContributor = seedData[0].deposit / contributorCount;
+            for (let index = 0; index < contributorCount; index++) {
+                seedData[0].contributors.push({addr: ethAddr, stakedAmount: stakePerContributor});
+            }
+
+            await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
+            expect(await serviceNodeRewards.serviceNodesLength()).to.equal(1);
+            verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
+        });
+
+        it("Fails if there are 11 contributors (pre-migration Oxen has a 10 contributor limit)", async function () {
+            seedData = [
+                {
+                    pubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 1100,
+                    contributors: []
+                },
+            ];
+
+            const contributorCount    = 11;
+            const ethAddr             = "0x66d801a70615979d82c304b7db374d11c232db66";
+            const stakePerContributor = seedData[0].deposit / contributorCount;
+            for (let index = 0; index < contributorCount; index++) {
+                seedData[0].contributors.push({addr: ethAddr, stakedAmount: stakePerContributor});
+            }
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
     });
 });
 


### PR DESCRIPTION
This goes ontop of https://github.com/oxen-io/eth-sn-contracts/pull/33 Both of these changes are necessary to make the testnet work. It was currently not possible to exit the network because there were no contributors configured in the session nodes that were migrated over.

The exit code checks that the wallet invoking the request was a contributor to the node they are trying to initiate a exit request on. Since the contributors were not populated this was flat-out rejected every time. This commit changes the seeding function to take in a struct with the contributor data.

This is currently being tested in the python script and is working, but, there are new issues that have now arisen having fixed this regarding the other endpoints since they have been updated.