### PR TITLE
Functions for fixing the stagenet

### DIFF
--- a/.openzeppelin/unknown-421614.json
+++ b/.openzeppelin/unknown-421614.json
@@ -4625,6 +4625,468 @@
           ]
         }
       }
+    },
+    "229bee5dac23488241d335352bb165977f5efea09789e8869ec23ca4e094885b": {
+      "address": "0x17820D67912F4c01B6EDF9a5459F92Da729e6a6E",
+      "txHash": "0xff34b55d6487e62cf7e9797447a3ce0575c631be9d85ffaf5f7a26e64e0bce7d",
+      "layout": {
+        "solcVersion": "0.8.20",
+        "storage": [
+          {
+            "label": "isStarted",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:20"
+          },
+          {
+            "label": "designatedToken",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_contract(IERC20)885",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:22"
+          },
+          {
+            "label": "foundationPool",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IERC20)885",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:23"
+          },
+          {
+            "label": "nextServiceNodeID",
+            "offset": 20,
+            "slot": "1",
+            "type": "t_uint64",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:33"
+          },
+          {
+            "label": "totalNodes",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:34"
+          },
+          {
+            "label": "blsNonSignerThreshold",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:35"
+          },
+          {
+            "label": "blsNonSignerThresholdMax",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:36"
+          },
+          {
+            "label": "signatureExpiry",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:37"
+          },
+          {
+            "label": "proofOfPossessionTag",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_bytes32",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:39"
+          },
+          {
+            "label": "rewardTag",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_bytes32",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:40"
+          },
+          {
+            "label": "removalTag",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_bytes32",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:41"
+          },
+          {
+            "label": "liquidateTag",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_bytes32",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:42"
+          },
+          {
+            "label": "hashToG2Tag",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_bytes32",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:43"
+          },
+          {
+            "label": "_stakingRequirement",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:45"
+          },
+          {
+            "label": "_maxContributors",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:46"
+          },
+          {
+            "label": "_liquidatorRewardRatio",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:47"
+          },
+          {
+            "label": "_poolShareOfLiquidationRatio",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:48"
+          },
+          {
+            "label": "_recipientRatio",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:49"
+          },
+          {
+            "label": "_serviceNodes",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_mapping(t_uint64,t_struct(ServiceNode)4020_storage)",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:100"
+          },
+          {
+            "label": "recipients",
+            "offset": 0,
+            "slot": "17",
+            "type": "t_mapping(t_address,t_struct(Recipient)4026_storage)",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:101"
+          },
+          {
+            "label": "serviceNodeIDs",
+            "offset": 0,
+            "slot": "18",
+            "type": "t_mapping(t_bytes_memory_ptr,t_uint64)",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:103"
+          },
+          {
+            "label": "_aggregatePubkey",
+            "offset": 0,
+            "slot": "19",
+            "type": "t_struct(G1Point)4267_storage",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:105"
+          },
+          {
+            "label": "_lastHeightPubkeyWasAggregated",
+            "offset": 0,
+            "slot": "21",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:106"
+          },
+          {
+            "label": "_numPubkeyAggregationsForHeight",
+            "offset": 0,
+            "slot": "22",
+            "type": "t_uint256",
+            "contract": "ServiceNodeRewards",
+            "src": "contracts/ServiceNodeRewards.sol:107"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)107_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Ownable2StepStorage)14_storage": {
+            "label": "struct Ownable2StepUpgradeable.Ownable2StepStorage",
+            "members": [
+              {
+                "label": "_pendingOwner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)56_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)180_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_struct(Contributor)3991_storage)dyn_storage": {
+            "label": "struct IServiceNodeRewards.Contributor[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_memory_ptr": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20)885": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_struct(Recipient)4026_storage)": {
+            "label": "mapping(address => struct IServiceNodeRewards.Recipient)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes_memory_ptr,t_uint64)": {
+            "label": "mapping(bytes => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_struct(ServiceNode)4020_storage)": {
+            "label": "mapping(uint64 => struct IServiceNodeRewards.ServiceNode)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Contributor)3991_storage": {
+            "label": "struct IServiceNodeRewards.Contributor",
+            "members": [
+              {
+                "label": "addr",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "stakedAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(G1Point)4267_storage": {
+            "label": "struct BN256G1.G1Point",
+            "members": [
+              {
+                "label": "X",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "Y",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Recipient)4026_storage": {
+            "label": "struct IServiceNodeRewards.Recipient",
+            "members": [
+              {
+                "label": "rewards",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "claimed",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(ServiceNode)4020_storage": {
+            "label": "struct IServiceNodeRewards.ServiceNode",
+            "members": [
+              {
+                "label": "next",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "prev",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "0"
+              },
+              {
+                "label": "operator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pubkey",
+                "type": "t_struct(G1Point)4267_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "addedTimestamp",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "leaveRequestTimestamp",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "deposit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "contributors",
+                "type": "t_array(t_struct(Contributor)3991_storage)dyn_storage",
+                "offset": 0,
+                "slot": "7"
+              }
+            ],
+            "numberOfBytes": "256"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable2Step": [
+            {
+              "contract": "Ownable2StepUpgradeable",
+              "label": "_pendingOwner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol:23",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -87,3 +87,17 @@ You can run `slither` a static analyzer separately from Echidna by executing:
 ```
 make analyze
 ```
+
+## Scripts
+
+- `scripts/attach-and-dump-sn-rewards-stats.js`
+
+  Attaches to the `ServiceNodeRewards` instance specified in the script and
+  dumps the current state of the contract. This script is RPC heavy as it
+  scrapes contributors and service nodes information which currently is done
+  with 1 request per entry.
+
+  This script can be run via hardhat, e.g:
+
+    npx hardhat run --network sepoliaarbitrum scripts/attach-and-dump-sn-rewards-stats.js
+

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -778,6 +778,16 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         emit BLSNonSignerThresholdMaxUpdated(newMax);
     }
 
+    // NOTE: Admin function to remove node by ID for stagenet debugging
+    function removeNodeBySNID(uint64[] calldata ids) external onlyOwner {
+        for (uint256 i = 0; i < ids.length; i++) {
+            uint64 serviceNodeID = ids[i];
+            IServiceNodeRewards.ServiceNode memory node = this.serviceNodes(serviceNodeID);
+            require(node.operator != address(0));
+            _removeBLSPublicKey(serviceNodeID, node.deposit);
+        }
+    }
+
     //////////////////////////////////////////////////////////////
     //                                                          //
     //                Non-state-changing functions              //

--- a/scripts/attach-and-dump-sn-rewards-stats.js
+++ b/scripts/attach-and-dump-sn-rewards-stats.js
@@ -1,0 +1,115 @@
+const { ethers } = require('hardhat');
+async function main() {
+    const sn_rewards_factory = await ethers.getContractFactory('ServiceNodeRewards');
+    const sn_rewards         = await sn_rewards_factory.attach('0xEF43cd64528eA89966E251d4FE17c660222D2c9d');
+
+    const aggregate_pubkey = await sn_rewards.aggregatePubkey();
+    console.log("Total Nodes:                        " + await sn_rewards.totalNodes());
+    console.log("Next Service Node ID:               " + await sn_rewards.nextServiceNodeID());
+    console.log("BLS Non Signer Threshold:           " + await sn_rewards.blsNonSignerThreshold());
+    console.log("BLS Non Signer Threshold Max:       " + await sn_rewards.blsNonSignerThresholdMax());
+    console.log("Aggregate Pubkey:                   " + aggregate_pubkey[0].toString(16) + " " + aggregate_pubkey[1].toString(16));
+    console.log("Last Height Pubkey Aggregated:      " + await sn_rewards._lastHeightPubkeyWasAggregated());
+    console.log("Num Pubkey Aggregations For Height: " + await sn_rewards._numPubkeyAggregationsForHeight());
+    console.log("Removal Tag:                        " + await sn_rewards.removalTag());
+    console.log("Reward Tag:                         " + await sn_rewards.rewardTag());
+
+    // NOTE: Print all the Session Node IDs via 'allServiceNodeIDs' into a JS structure
+    const all_sn_ids       = await sn_rewards.allServiceNodeIDs(); // -> (sn_id[], (bls_x, bls_y)[])
+    const sn_id_array      = all_sn_ids[0];
+    const bls_pubkey_array = all_sn_ids[1];
+
+    let js_code_bls_key_array = "  const contract_bls_keys = [\n";
+    for (let i = 0; i < all_sn_ids[0].length; i++) {
+        const sn_id      = sn_id_array[i];
+        const bls_x_u256 = bls_pubkey_array[i][0];
+        const bls_y_u256 = bls_pubkey_array[i][1];
+
+        js_code_bls_key_array += "    ";
+        js_code_bls_key_array += "/*" + i.toString().padStart(4) + "*/ {";
+        js_code_bls_key_array += "'id': " + sn_id.toString().padStart(5) + ", ";
+        js_code_bls_key_array += "'bls_pubkey': {'x': BigInt('0x" + bls_x_u256.toString(16).padStart(64, '0') + "'), 'y': BigInt('0x" + bls_y_u256.toString(16).padStart(64, '0') + "')}";
+        js_code_bls_key_array += "},\n";
+    }
+    js_code_bls_key_array += "  ];";
+    console.log("All Service Node IDs:\n" + js_code_bls_key_array);
+
+    // NOTE: Enumerate all contributors into a hash table
+    console.log("Enumerating contributors, this may take awhile ...");
+    let contributor_map = new Map(); // (eth_addr -> (total_staked, rewards_balance, rewards_claimed))
+    for (let i = 0; i < all_sn_ids[1].length; i++) {
+        const sn_id             = sn_id_array[i];
+        const sn_info           = await sn_rewards.serviceNodes(sn_id);
+        const contributor_array = sn_info[7];
+
+        for (let contributor_index = 0; contributor_index < contributor_array.length; contributor_index++) {
+            const contributor   = contributor_array[contributor_index];
+            const eth_addr      = contributor[0];
+            const staked_amount = contributor[1];
+
+            let total_staked_sum = staked_amount;
+            if (contributor_map.has(eth_addr))
+                total_staked_sum += contributor_map.get(eth_addr).total_staked
+
+            contributor_map.set(eth_addr,
+                {
+                    total_staked: total_staked_sum,
+                    rewards_balance: 0n,
+                    rewards_claimed: 0n
+                }
+            );
+        }
+    }
+
+    // NOTE: Enumerate all the rewards
+    console.log("Enumerating rewards for " + contributor_map.size + " contributor(s), this may take awhile ...");
+    for (let [eth_addr, contributor_info] of contributor_map) {
+        const rewards_info = await sn_rewards.recipients(eth_addr); // (balance, claimed)
+        contributor_map.set(eth_addr,
+            {
+                total_staked: contributor_info.total_staked,
+                rewards_balance: rewards_info[0],
+                rewards_claimed: rewards_info[1],
+            }
+        );
+    }
+
+    // NOTE: Print all active contributor rewards
+    let js_code_contributor_rewards = "  const contributor_rewards = [\n";
+    for (let [eth_addr, contributor_info] of contributor_map) {
+        js_code_contributor_rewards += "    {";
+        js_code_contributor_rewards += "'address': " + eth_addr + ", ";
+        js_code_contributor_rewards += "'total_staked': " + contributor_info.total_staked + ", ";
+        js_code_contributor_rewards += "'rewards_balance': " + contributor_info.rewards_balance + ", ";
+        js_code_contributor_rewards += "'rewards_claimed': " + contributor_info.rewards_claimed + ", ";
+        js_code_contributor_rewards += "},\n";
+    }
+    js_code_contributor_rewards += "  ];";
+    console.log("Active Contributor Rewards:\n" + js_code_contributor_rewards);
+
+    // TODO: Below is template code for claiming rewards
+    /*
+    const recipientAddress = '0x3e20171Ee536f616d82094A72cb45D831f3B4449';
+    console.log(await sn_rewards.recipients(recipientAddress));
+    const totalNodes       = Number(await sn_rewards.totalNodes());
+    const recipientRewards = 91720222828n;
+    const blsSignature = {
+        sigs0: BigInt('0x12a520fb303255787ffb8e6c6ee7efa2457897e45f06131f15b6800c5edc33f9'),
+        sigs1: BigInt('0x2cf0376d4c77616f1005432249ff672f0d7649bb8474db6cab5e0ee963e0368b'),
+        sigs2: BigInt('0x11f6637a4b5713d398cc6fcf68428c5359c57aa08b0874d02266235b2b35b83a'),
+        sigs3: BigInt('0x049f82222409bc503d936b8ba9f4b2f984dc5750ded4f0d78b83ad0b098c1caa'),
+    };
+
+    const ids = [
+        166
+    ];
+    console.log("There were " + ids.length + " non signers and " + (totalNodes - ids.length) + " signers (" + totalNodes + " altogether)")
+    await sn_rewards.updateRewardsBalance(
+        recipientAddress,
+        recipientRewards,
+        blsSignature,
+        ids
+    );
+    */
+}
+main();


### PR DESCRIPTION
In absence of exit and liqudations stagenet was upgraded with a remove node function that was introduced prior but removed immediately after it was used. This time we keep it around because the network currently accumulates dead nodes quite quickly when it is resumed and so it's useful to have to flush out nodes from the network.

Accumulating dead nodes is an issue whilst the delayed confirmations approach feature is rolled out on oxen-core which is causing normal behaving nodes to be deregistered incorrectly as they get partitioned from the network due to consensus bugs.