### PR TITLE
Add bls<->ed25519 mapping to reject dupe keys

### DIFF
--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -11,8 +11,9 @@ interface IServiceNodeRewards {
     }
 
     struct SeedServiceNode {
-        BN256G1.G1Point pubkey;
-        Contributor[] contributors;
+        BN256G1.G1Point blsPubkey;
+        uint256         ed25519Pubkey;
+        Contributor[]   contributors;
     }
 
     /// @notice Represents a service node in the network.

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -18,14 +18,15 @@ interface IServiceNodeRewards {
 
     /// @notice Represents a service node in the network.
     struct ServiceNode {
-        uint64 next;
-        uint64 prev;
-        address operator;
-        BN256G1.G1Point pubkey;
-        uint256 addedTimestamp;
-        uint256 leaveRequestTimestamp;
-        uint256 deposit;
-        Contributor[] contributors;
+        uint64          next;
+        uint64          prev;
+        address         operator;
+        BN256G1.G1Point blsPubkey;
+        uint256         addedTimestamp;
+        uint256         leaveRequestTimestamp;
+        uint256         deposit;
+        Contributor[]   contributors;
+        uint256         ed25519Pubkey;
     }
 
     /// @notice Represents a recipient of rewards, how much they can claim and how much previously claimed.

--- a/contracts/test/MockServiceNodeRewards.sol
+++ b/contracts/test/MockServiceNodeRewards.sol
@@ -42,7 +42,7 @@ contract MockServiceNodeRewards is Ownable {
     ) public {
         _serviceNodes[nextServiceNodeID].operator = msg.sender;
         _serviceNodes[nextServiceNodeID].deposit = stakingRequirement;
-        _serviceNodes[nextServiceNodeID].pubkey = pubkey;
+        _serviceNodes[nextServiceNodeID].blsPubkey = pubkey;
 
         // Initialize the contributors array for the service node
         uint256 contributorsLength = contributors.length;

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -169,10 +169,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(rewards_contract.serviceNodesLength() == 0);
         ServiceNodeList snl(2);
         for(auto& node : snl.nodes) {
-            const auto pubkey = node.getPublicKeyHex();
+            const auto pubkey              = node.getPublicKeyHex();
             const auto proof_of_possession = node.proofOfPossession(config.CHAIN_ID, contract_address, senderAddress, "pubkey");
-            tx = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey", "sig", 0);
-            hash = signer.sendTransaction(tx, seckey);
+            tx                             = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey", "sig", 0);
+            hash                           = signer.sendTransaction(tx, seckey);
             REQUIRE(hash != "");
             REQUIRE(defaultProvider.transactionSuccessful(hash));
         }

--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -58,12 +58,14 @@ describe("ServiceNodeRewards Contract Tests", function () {
     describe("Seeding the public key as owner", function () {
 
         it("Should correctly seed public key list with a single item", async function () {
+            let ed25519Generator = 1n;
             const seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x0b5e634d0407c021e9e9dd9d03c4965810e236fef0955ab345e1d049a0438ec6",
                         Y: "0x1dbb7bf2b1f5340d4b5c466a0641b00cd3a9d9588c7bcad1c3158bdcc65c3332",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -76,18 +78,20 @@ describe("ServiceNodeRewards Contract Tests", function () {
             await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
             expect(await serviceNodeRewards.serviceNodesLength()).to.equal(1);
             let aggregate_pubkey = await serviceNodeRewards.aggregatePubkey();
-            expect(aggregate_pubkey[0]).to.equal(seedData[0].pubkey.X)
-            expect(aggregate_pubkey[1]).to.equal(seedData[0].pubkey.Y)
+            expect(aggregate_pubkey[0]).to.equal(seedData[0].blsPubkey.X)
+            expect(aggregate_pubkey[1]).to.equal(seedData[0].blsPubkey.Y)
             verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
         });
 
         it("Should correctly seed public key list with multiple items", async function () {
+            let ed25519Generator = 1n;
             const seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -96,11 +100,12 @@ describe("ServiceNodeRewards Contract Tests", function () {
                     ]
                 },
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x2ef6b73ab4486484de80681753a6a90c6a88a71f60aace9520fe6bb8bb8de34e",
                         Y: "0x29b8f2a87a758a89c394b121298b946dce9ada3226b5d008e54e54ddcd9e5227",
                     },
                     deposit: 2000,
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -132,12 +137,14 @@ describe("ServiceNodeRewards Contract Tests", function () {
         });
 
         it("Should fail to seed public key list with duplicate items", async function () {
+            let ed25519Generator = 1n;
             const seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -146,10 +153,11 @@ describe("ServiceNodeRewards Contract Tests", function () {
                     ]
                 },
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -164,12 +172,14 @@ describe("ServiceNodeRewards Contract Tests", function () {
         });
 
         it("Fails when sum of contributor stakes do not add up the staking requirement", async function () {
+            let ed25519Generator = 1n;
             const seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -182,13 +192,14 @@ describe("ServiceNodeRewards Contract Tests", function () {
             await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
         });
 
-        it("Fails if the BLS pubkey is the zero key", async function () {
+        it("Fails if the Ed25519 pubkey is the zero key", async function () {
             const seedData = [
                 {
-                    pubkey: {
-                        X: "0x0000000000000000000000000000000000000000000000000000000000000000",
-                        Y: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    blsPubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: 0n,
                     contributors: [
                         {
                             addr: "0x66d801a70615979d82c304b7db374d11c232db66",
@@ -201,13 +212,156 @@ describe("ServiceNodeRewards Contract Tests", function () {
             await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
         });
 
-        it("Fails if there are no contributors", async function () {
+        it("Fails if the BLS pubkey is the zero key", async function () {
+            let ed25519Generator = 1n;
             const seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
+                        X: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        Y: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    },
+                    ed25519Pubkey: ed25519Generator++,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Fails if the BLS pubkey X component is zero", async function () {
+            let ed25519Generator = 1n;
+            const seedData = [
+                {
+                    blsPubkey: {
+                        X: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    ed25519Pubkey: ed25519Generator++,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Fails if the BLS pubkey Y component is zero", async function () {
+            let ed25519Generator = 1n;
+            const seedData = [
+                {
+                    blsPubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    },
+                    ed25519Pubkey: ed25519Generator++,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner).seedPublicKeyList(seedData)).to.be.reverted;
+        });
+
+        it("Fails if the BLS pubkey is repeated", async function () {
+            let ed25519Generator = 1n;
+            const seedData = [
+                {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+                {
+                    blsPubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    deposit: 2000,
+                    ed25519Pubkey: ed25519Generator++,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner)
+                                           .seedPublicKeyList(seedData))
+                  .to
+                  .be
+                  .revertedWithCustomError(serviceNodeRewards, "BLSPubkeyAlreadyExists");
+        });
+
+        it("Fails if the Ed25519 pubkey is repeated", async function () {
+            let ed25519Generator = 1n;
+            const seedData = [
+                {
+                    blsPubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    ed25519Pubkey: ed25519Generator,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+                {
+                    blsPubkey: {
+                        X: "0x2ef6b73ab4486484de80681753a6a90c6a88a71f60aace9520fe6bb8bb8de34e",
+                        Y: "0x29b8f2a87a758a89c394b121298b946dce9ada3226b5d008e54e54ddcd9e5227",
+                    },
+                    deposit: 2000,
+                    ed25519Pubkey: ed25519Generator,
+                    contributors: [
+                        {
+                            addr: "0x66d801a70615979d82c304b7db374d11c232db66",
+                            stakedAmount: staking_req,
+                        }
+                    ]
+                },
+            ];
+
+            await expect(serviceNodeRewards.connect(owner)
+                                           .seedPublicKeyList(seedData))
+                  .to
+                  .be
+                  .revertedWithCustomError(serviceNodeRewards, "Ed25519PubkeyHasPairedBLSPubkey");
+        });
+
+        it("Fails if there are no contributors", async function () {
+            let ed25519Generator = 1n;
+            const seedData = [
+                {
+                    blsPubkey: {
+                        X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
+                        Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
+                    },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: []
                 },
             ];
@@ -216,12 +370,14 @@ describe("ServiceNodeRewards Contract Tests", function () {
         });
 
         it("Supports 10 contributors", async function () {
+            let ed25519Generator = 1n;
             seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: []
                 },
             ];
@@ -239,12 +395,14 @@ describe("ServiceNodeRewards Contract Tests", function () {
         });
 
         it("Fails if there are 11 contributors (pre-migration Oxen has a 10 contributor limit)", async function () {
+            let ed25519Generator = 1n;
             seedData = [
                 {
-                    pubkey: {
+                    blsPubkey: {
                         X: "0x12c59fb45c483177873406e5b74a2e6914fe25a591185f30d2788e737da6f2ed",
                         Y: "0x016e56f330d11faaf90ec281b1c4184e98a52d4043075fcbe45a976de0f795ab",
                     },
+                    ed25519Pubkey: ed25519Generator++,
                     contributors: []
                 },
             ];
@@ -261,6 +419,7 @@ describe("ServiceNodeRewards Contract Tests", function () {
         });
 
         it("Should handle a huge seed list", async function () {
+            let ed25519Generator = 1n;
             let Px = [
                 BigInt("0x001c7e60fb1f6ce4c33be823d1e246c04df8fc7a7bcd28dd4d7360a68044de0c"),
                 BigInt("0x0025532e9cd87d9d6e5afd2277443faf6a1a90fabe47183098ca0a8c05aa510c"),
@@ -6278,8 +6437,12 @@ describe("ServiceNodeRewards Contract Tests", function () {
             for (let i = 0; i < 2000; i += incr) {
                 let seed_sns = [];
                 for (let j = 0; j < incr; j++) {
-                    seed_sns.push({"pubkey": [Px[i+j], Py[i+j]], "deposit": 120000000000n,
-                        "contributors": contributors[i+j]});
+                    seed_sns.push({
+                        "blsPubkey": [Px[i+j], Py[i+j]],
+                        "deposit": 120000000000n,
+                        "ed25519Pubkey": ed25519Generator++,
+                        "contributors": contributors[i+j]
+                    });
                 }
                 let tx = await contract.seedPublicKeyList(seed_sns);
 

--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -2,8 +2,8 @@ const { expect } = require("chai");
 const { ethers, upgrades } = require("hardhat");
 
 async function verifySeedData(contractSN, seedEntry) {
-    expect(contractSN.pubkey[0]).to.equal(BigInt(seedEntry.pubkey.X));
-    expect(contractSN.pubkey[1]).to.equal(BigInt(seedEntry.pubkey.Y));
+    expect(contractSN.blsPubkey[0]).to.equal(BigInt(seedEntry.blsPubkey.X));
+    expect(contractSN.blsPubkey[1]).to.equal(BigInt(seedEntry.blsPubkey.Y));
     expect(contractSN.deposit).to.equal(BigInt(seedEntry.deposit));
     expect(contractSN.contributors.length).to.equal(seedEntry.contributors.length);
     for (let contributorIndex = 0; contributorIndex < contractSN.contributors.length; contributorIndex++) {
@@ -350,7 +350,7 @@ describe("ServiceNodeRewards Contract Tests", function () {
                                            .seedPublicKeyList(seedData))
                   .to
                   .be
-                  .revertedWithCustomError(serviceNodeRewards, "Ed25519PubkeyHasPairedBLSPubkey");
+                  .revertedWithCustomError(serviceNodeRewards, "Ed25519PubkeyAlreadyExists");
         });
 
         it("Fails if there are no contributors", async function () {

--- a/test/unit-js/TestnetServiceNodeRewardsTest.js
+++ b/test/unit-js/TestnetServiceNodeRewardsTest.js
@@ -2,8 +2,8 @@ const { expect } = require("chai");
 const { ethers, upgrades } = require("hardhat");
 
 async function verifySeedData(contractSN, seedEntry) {
-    expect(contractSN.pubkey[0]).to.equal(BigInt(seedEntry.blsPubkey.X));
-    expect(contractSN.pubkey[1]).to.equal(BigInt(seedEntry.blsPubkey.Y));
+    expect(contractSN.blsPubkey[0]).to.equal(BigInt(seedEntry.blsPubkey.X));
+    expect(contractSN.blsPubkey[1]).to.equal(BigInt(seedEntry.blsPubkey.Y));
     expect(contractSN.deposit).to.equal(BigInt(seedEntry.deposit));
     expect(contractSN.contributors.length).to.equal(seedEntry.contributors.length);
     for (let contributorIndex = 0; contributorIndex < contractSN.contributors.length; contributorIndex++) {


### PR DESCRIPTION
The mapping is used to outright reject anyone that tries to register a different BLS key for the same Ed25519 key, but similarly, also, a different Ed25519 key for the same BLS key.

If these make it through the contract, the contract locks up collateral and then the onus of freeing up those funds ends up in the oxen codebase. There are issues in this because the link between L2 and Oxen is more vulnerable than just outright preventing us from getting into the situation in the first place.

--

 Note C++ tests are broken because of some renaming that happened in this PR and I believe we are looking to sunset that so I haven't updated them but certainly can if that's non-negotiable.

--

Additionally some small cleanup in the rewards contract

1. Public variables have an automatically generated getter function so there's no need to re-specify those in the rewards contract itself which just bloats the contract with duplicate code.
2. Inline `addBLSPublicKey` because there's no other auxiliary contract in our ecosystem that needs to be able to parameterise the caller of that function.