### PR TITLE
Fix multi-contrib nodes setting contract as operator of node

### DIFF
--- a/test/cpp/test/src/hash.cpp
+++ b/test/cpp/test/src/hash.cpp
@@ -13,10 +13,10 @@ std::string_view DOMAIN_SEPARATION_TAG_BYTES32 =
 
 std::array<std::string, 4> convertToHexStrings(const uint8_t md[128]) {
     std::array<std::string, 4> result;
-    for (int i = 0; i < 4; ++i) {
+    for (size_t i = 0; i < result.max_size(); ++i) {
         std::stringstream ss;
         ss << "0x";
-        for (int j = 0; j < 32; ++j) {
+        for (size_t j = 0; j < 32; ++j) {
             ss << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(md[i * 32 + j]);
         }
         result[i] = ss.str();

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -39,7 +39,10 @@ int main(int argc, char *argv[]) {
     signer.provider->addClient("Client", std::string(config.RPC_URL));
     erc20_contract.provider.addClient("Client", std::string(config.RPC_URL));
     rewards_contract.provider.addClient("Client", std::string(config.RPC_URL));
-    contract_address = defaultProvider.getContractDeployedInLatestBlock();
+
+    // NOTE: The SN rewards contract has a deterministic deployment address
+    // because we use a pre-determined debug wallet provided by Hardhat.
+    contract_address = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707";
 
     // NOTE: Setup keys
     seckey        = ethyl::utils::fromHexString(std::string(config.PRIVATE_KEY));


### PR DESCRIPTION
In my integration tests curiously multi-contributor contracts were failing until I realised that we were using `msg.sender` as the operator which is incorrect in the multi-contributor flow.

When you have a multi-contributor contract, that calls `addBLSPublicKey` on the rewards contract on the operator's behalf. This means that `msg.sender` is set to the multi-contribution contract. Then, in `addBLSPublicKey` we'd use the `msg.sender` to `validateProofOfPossession` but also emit a `NewServiceNodeV2` log with the contract address. 

This is incorrect and would prevent the operator from being able to exit the node. It'd also fail checks in core where it expects the 1st contributor to be the operator. The fix here is to correctly use `msg.sender` for transferring the stake and the 1st contributor as the operator for the SN metadata.