### PR TITLE
Allow (rate limited) leave requests events to be repeated

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -203,7 +203,6 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     error ContractNotStarted();
     error ContributionTotalMismatch(uint256 required, uint256 provided);
     error DeleteSentinelNodeNotAllowed();
-    error EarlierLeaveRequestMade(uint64 serviceNodeID, address contributor);
     error FirstContributorMismatch(address operator, address contributor);
     error InsufficientBLSSignatures(uint256 numSigners, uint256 requiredSigners);
     error InsufficientContributors();
@@ -488,11 +487,14 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         }
         if (!isContributor) revert CallerNotContributor(serviceNodeID, caller);
 
-        if (_serviceNodes[serviceNodeID].leaveRequestTimestamp != 0)
-            revert EarlierLeaveRequestMade(serviceNodeID, caller);
-        if (isSmall && block.timestamp < _serviceNodes[serviceNodeID].addedTimestamp + SMALL_CONTRIBUTOR_LEAVE_DELAY)
-            revert SmallContributorLeaveTooEarly(serviceNodeID, caller);
-        _serviceNodes[serviceNodeID].leaveRequestTimestamp = block.timestamp;
+        if (_serviceNodes[serviceNodeID].leaveRequestTimestamp == 0) {
+            if (isSmall && block.timestamp < _serviceNodes[serviceNodeID].addedTimestamp + SMALL_CONTRIBUTOR_LEAVE_DELAY)
+                revert SmallContributorLeaveTooEarly(serviceNodeID, caller);
+            _serviceNodes[serviceNodeID].leaveRequestTimestamp = block.timestamp;
+        }
+        // Otherwise this node is already unlocking, but we allow a repeated call to reissue the
+        // event (in case the original did not get properly handled by the oxen chain for some
+        // reason).
         emit ServiceNodeRemovalRequest(serviceNodeID, caller, _serviceNodes[serviceNodeID].blsPubkey);
     }
 

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -33,7 +33,17 @@ interface IServiceNodeRewards {
         address         operator;
         BN256G1.G1Point blsPubkey;
         uint256         addedTimestamp;
+        /// Timestamp of the first time a leave request was requeste on the node
         uint256         leaveRequestTimestamp;
+
+        /// Timestamp of the latest time a leave request was requested on the
+        /// node. Multiple leave requests are permitted for node in the event
+        /// that the Session network rejects the request for various possible
+        /// reasons.
+        ///
+        /// Subsequent leave requests can be overlapped to get the network to
+        /// re-emit the event to be witnessed by the Session network again.
+        uint256         latestLeaveRequestTimestamp;
         uint256         deposit;
         Contributor[]   contributors;
         uint256         ed25519Pubkey;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -27,7 +27,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 100,
+        runs: 1,
       },
       metadata: {
         // do not include the metadata hash, since this is machine dependent

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -29,6 +29,7 @@ struct ContractServiceNode {
     bls::PublicKey                pubkey;
     uint64_t                      addedTimestamp;
     uint64_t                      leaveRequestTimestamp;
+    uint64_t                      latestLeaveRequestTimestamp;
     std::string                   deposit;
     std::vector<Contributor>      contributors;
     std::string                   ed25519Pubkey;

--- a/test/cpp/src/service_node_rewards_contract.cpp
+++ b/test/cpp/src/service_node_rewards_contract.cpp
@@ -36,19 +36,20 @@ ContractServiceNode ServiceNodeRewardsContract::serviceNodes(uint64_t index)
         const size_t        ADDRESS_HEX_SIZE               = 32 * 2;
         const size_t        ETH_ADDRESS_HEX_SIZE           = 20 * 2;
 
-        ContractServiceNode result                   = {};
-        size_t              walkIt                   = 0;
-        std::string_view    initialElementOffset     = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += initialElementOffset.size();
-        std::string_view    nextHex                  = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += nextHex.size();
-        std::string_view    prevHex                  = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += prevHex.size();
-        std::string_view    operatorAddressHex       = callResultIt.substr(walkIt, ADDRESS_HEX_SIZE);  walkIt += operatorAddressHex.size();
-        std::string_view    pubkeyHex                = callResultIt.substr(walkIt, BLS_PKEY_HEX_SIZE); walkIt += pubkeyHex.size();
-        std::string_view    addedTimestampHex        = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += addedTimestampHex.size();
-        std::string_view    leaveRequestTimestampHex = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += leaveRequestTimestampHex.size();
-        std::string_view    depositHex               = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += depositHex.size();
-        std::string_view    contributorOffsetHex     = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += contributorOffsetHex.size();
-        std::string_view    ed25519PubkeyHex         = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += ed25519PubkeyHex.size();
-        std::string_view    contributorCountHex      = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += contributorCountHex.size();
+        ContractServiceNode result                         = {};
+        size_t              walkIt                         = 0;
+        std::string_view    initialElementOffset           = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += initialElementOffset.size();
+        std::string_view    nextHex                        = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += nextHex.size();
+        std::string_view    prevHex                        = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += prevHex.size();
+        std::string_view    operatorAddressHex             = callResultIt.substr(walkIt, ADDRESS_HEX_SIZE);  walkIt += operatorAddressHex.size();
+        std::string_view    pubkeyHex                      = callResultIt.substr(walkIt, BLS_PKEY_HEX_SIZE); walkIt += pubkeyHex.size();
+        std::string_view    addedTimestampHex              = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += addedTimestampHex.size();
+        std::string_view    leaveRequestTimestampHex       = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += leaveRequestTimestampHex.size();
+        std::string_view    latestLeaveRequestTimestampHex = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += leaveRequestTimestampHex.size();
+        std::string_view    depositHex                     = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += depositHex.size();
+        std::string_view    contributorOffsetHex           = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += contributorOffsetHex.size();
+        std::string_view    ed25519PubkeyHex               = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += ed25519PubkeyHex.size();
+        std::string_view    contributorCountHex            = callResultIt.substr(walkIt, U256_HEX_SIZE);     walkIt += contributorCountHex.size();
 
         // NOTE: Deserialize linked list
         result.next                = ethyl::utils::hexStringToU64(nextHex);
@@ -87,9 +88,12 @@ ContractServiceNode ServiceNodeRewardsContract::serviceNodes(uint64_t index)
 
         // NOTE: Deserialise metadata
         result.addedTimestamp = ethyl::utils::hexStringToU64(addedTimestampHex);
-        result.leaveRequestTimestamp = ethyl::utils::hexStringToU64(leaveRequestTimestampHex);
-        result.deposit               = depositHex;
-        result.ed25519Pubkey         = ed25519PubkeyHex;
+        result.leaveRequestTimestamp =
+            ethyl::utils::hexStringToU64(leaveRequestTimestampHex);
+        result.latestLeaveRequestTimestamp =
+            ethyl::utils::hexStringToU64(latestLeaveRequestTimestampHex);
+        result.deposit = depositHex;
+        result.ed25519Pubkey = ed25519PubkeyHex;
         return result;
     } catch (const std::exception& e) {
         throw std::runtime_error{std::string("response: ") + callResult.dump()};


### PR DESCRIPTION
Further iterates on https://github.com/oxen-io/eth-sn-contracts/pull/95 this adds a rate limit how often the leave request can be initiated because it's spammable. In the optimistic case, the chain will take around ~15mins to confirm so the it should rate-limit the request to at least once per 15 minutes. In this commit I've chosen 1 hour.