### PR TITLE
Prep for stagenet relaunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ make analyze
 
   This script can be run via hardhat, e.g:
 
-    npx hardhat run --network sepoliaarbitrum scripts/attach-and-dump-sn-rewards-stats.js
+    npx hardhat run --network arbitrumSepolia scripts/attach-and-dump-sn-rewards-stats.js
 

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -224,6 +224,9 @@ contract ServiceNodeContribution is Shared, IServiceNodeContribution {
     function updateBeneficiary(address newBeneficiary) external { _updateBeneficiary(msg.sender, newBeneficiary); }
 
     function _updateBeneficiary(address stakerAddr, address newBeneficiary) private {
+        if (status != Status.OpenForPublicContrib && status != Status.WaitForFinalized)
+            revert BeneficiaryUpdatingDisabledNodeIsNotOpen(_serviceNodeParams.serviceNodePubkey);
+
         address desiredBeneficiary = deriveBeneficiary(stakerAddr, newBeneficiary);
         address oldBeneficiary     = address(0);
         bool updated               = false;

--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -509,6 +509,11 @@ contract ServiceNodeContribution is Shared, IServiceNodeContribution {
             result = 0;
         } else {
             SENT.safeTransfer(toRemove, result);
+
+            // NOTE: Reopen the contract for contribution if we were previously
+            // ready to be finalized (e.g. fully collateralised)
+            if (status == Status.WaitForFinalized)
+                status = Status.OpenForPublicContrib;
         }
 
         return result;

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -503,7 +503,6 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         if (!isContributor)
             revert CallerNotContributor(serviceNodeID, caller);
 
-        ServiceNode storage sn = _serviceNodes[serviceNodeID];
         if (sn.leaveRequestTimestamp == 0) {
             if (isSmall && block.timestamp < sn.addedTimestamp + SMALL_CONTRIBUTOR_LEAVE_DELAY)
                 revert SmallContributorLeaveTooEarly(serviceNodeID, caller);

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -834,25 +834,20 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     //                                                          //
     //////////////////////////////////////////////////////////////
 
-    // @notice Publically allow anyone to recalculate the total nodes in the
-    // contract
-    function updateServiceNodesLength() public {
-        totalNodes = serviceNodesLength();
-    }
-
-    // @notice Publically allow anyone to recalculate the aggregate public key
-    // in the smart contract
-    function updateAggregatePubkey() public {
+    // @notice Publically allow anyone to recalculate the total nodes and
+    // aggregate public key in the smart contract
+    function rederiveTotalNodesAndAggregatePubkey() public {
+        totalNodes = 0;
         uint64 currentNode = _serviceNodes[LIST_SENTINEL].next;
-        for (uint64 i = 0; currentNode != LIST_SENTINEL; ) {
+        while (currentNode != LIST_SENTINEL) {
             ServiceNode storage sn = _serviceNodes[currentNode];
-            if (i == 0) {
+            if (totalNodes == 0) {
                 _aggregatePubkey = sn.blsPubkey;
             } else {
                 _aggregatePubkey = BN256G1.add(_aggregatePubkey, sn.blsPubkey);
             }
             currentNode = sn.next;
-            unchecked { i += 1; }
+            unchecked { totalNodes += 1; }
         }
     }
 
@@ -992,20 +987,6 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     function signatureTimestampHasExpired(uint256 timestamp) private view returns (bool result) {
         result = block.timestamp > timestamp + signatureExpiry;
         return result;
-    }
-
-    /// @notice Counts the number of service nodes in the linked list.
-    /// @return count The total number of service nodes in the list.
-    function serviceNodesLength() public view returns (uint256 count) {
-        uint64 currentNode = _serviceNodes[LIST_SENTINEL].next;
-        count = 0;
-
-        while (currentNode != LIST_SENTINEL) {
-            count++;
-            currentNode = _serviceNodes[currentNode].next;
-        }
-
-        return count;
     }
 
     /// @notice The maximum number of pubkey aggregations permitted for the

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -162,7 +162,6 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     // EVENTS
     event NewSeededServiceNode(uint64 indexed serviceNodeID, BN256G1.G1Point blsPubkey, uint256 ed25519Pubkey);
     event NewServiceNodeV2(
-        uint8 version,
         uint64 indexed serviceNodeID,
         address initiator,
         BN256G1.G1Point pubkey,
@@ -424,7 +423,7 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         }
 
         updateBLSNonSignerThreshold();
-        emit NewServiceNodeV2(0, allocID, operator, blsPubkey, serviceNodeParams, contributors);
+        emit NewServiceNodeV2(allocID, operator, blsPubkey, serviceNodeParams, contributors);
         SafeERC20.safeTransferFrom(designatedToken, msg.sender, address(this), stakingRequirement);
     }
 

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -107,6 +107,7 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         _serviceNodes[LIST_SENTINEL].prev = LIST_SENTINEL;
         _serviceNodes[LIST_SENTINEL].next = LIST_SENTINEL;
         __Ownable_init(msg.sender);
+        __Pausable_init();
     }
 
     mapping(uint64 => ServiceNode) private _serviceNodes;

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -1054,22 +1054,6 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         return (ids, pubkeys);
     }
 
-    /// @notice Getter for obtaining all registered service node pubkeys at once
-    /// @return pubkeys array of all currently registered pubkeys
-    function allServiceNodePubkeys() external view returns (BN256G1.G1Point[] memory pubkeys) {
-        pubkeys = new BN256G1.G1Point[](totalNodes);
-
-        uint64 currentNode = _serviceNodes[LIST_SENTINEL].next;
-        for (uint64 i = 0; currentNode != LIST_SENTINEL; ) {
-            ServiceNode storage sn = _serviceNodes[currentNode];
-            pubkeys[i]             = sn.blsPubkey;
-            currentNode            = sn.next;
-            unchecked { i += 1; }
-        }
-
-        return pubkeys;
-    }
-
     /// @dev Builds a tag string using a base tag and contract-specific
     /// information. This is used when signing messages to prevent reuse of
     /// signatures across different domains (chains/functions/contracts)

--- a/contracts/interfaces/IServiceNodeContribution.sol
+++ b/contracts/interfaces/IServiceNodeContribution.sol
@@ -79,17 +79,18 @@ interface IServiceNodeContribution {
     //                                                          //
     //////////////////////////////////////////////////////////////
 
-    error CalcMinContributionGivenBadContribArgs       (uint256 numContributors, uint256 maxNumContributors);
+    error CalcMinContributionGivenBadContribArgs  (uint256 numContributors, uint256 maxNumContributors);
     /// @notice Contract is not in a state where it can accept contributions
-    error ContributeFundsNotPossible                   (Status status);
-    error ContributionBelowMinAmount                   (uint256 contributed, uint256 min);
-    error ContributionBelowReservedAmount              (uint256 contributed, uint256 reserved);
-    error ContributionExceedsStakingRequirement        (uint256 totalContributed, uint256 totalReserved, uint256 stakingRequirement);
-    error DuplicateAddressInReservedContributor        (uint256 index);
-    error FeeExceedsPossibleValue                      (uint16 fee, uint16 max);
-    error FeeUpdateNotPossible                         (Status status);
-    error FinalizeNotPossible                          (Status status);
-    error FirstContributionMustBeOperator              (address contributor, address operator);
+    error ContributeFundsNotPossible              (Status status);
+    error ContributionBelowMinAmount              (uint256 contributed, uint256 min);
+    error ContributionBelowReservedAmount         (uint256 contributed, uint256 reserved);
+    error ContributionExceedsStakingRequirement   (uint256 totalContributed, uint256 totalReserved, uint256 stakingRequirement);
+    error DuplicateAddressInReservedContributor   (uint256 index);
+    error FeeExceedsPossibleValue                 (uint16 fee, uint16 max);
+    error FeeUpdateNotPossible                    (Status status);
+    error FinalizeNotPossible                     (Status status);
+    error FirstContributionMustBeOperator         (address contributor, address operator);
+    error BeneficiaryUpdatingDisabledNodeIsNotOpen(uint256 ed25519Pubkey);
 
     /// @notice A wallet has attempted to contribute to the contract
     /// before the operator's wallet has contributed.

--- a/contracts/interfaces/IServiceNodeContributionFactory.sol
+++ b/contracts/interfaces/IServiceNodeContributionFactory.sol
@@ -5,16 +5,14 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IServiceNodeRewards.sol";
 
 interface IServiceNodeContributionFactory {
-    function SENT()                     external view returns (IERC20);
     function stakingRewardsContract()   external view returns (IServiceNodeRewards);
-    function maxContributors()          external view returns (uint256);
     function deployedContracts(address) external view returns (bool);
 
     function deploy(BN256G1.G1Point calldata key,
                     IServiceNodeRewards.BLSSignatureParams calldata sig,
                     IServiceNodeRewards.ServiceNodeParams calldata params,
                     IServiceNodeRewards.ReservedContributor[] calldata reserved,
-                    bool manualFinalize) external;
+                    bool manualFinalize) external returns (address result);
 
     function owns(address contractAddress) external view returns (bool);
 }

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -87,7 +87,6 @@ interface IServiceNodeRewards {
     function serviceNodes(uint64) external view returns (ServiceNode memory);
     function serviceNodeIDs(bytes memory) external view returns (uint64);
     function allServiceNodeIDs() external view returns (uint64[] memory ids, BN256G1.G1Point[] memory pubkeys);
-    function allServiceNodePubkeys() external view returns (BN256G1.G1Point[] memory pubkeys);
     function stakingRequirement() external view returns (uint256);
     function totalNodes() external view returns (uint256);
 

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -82,7 +82,7 @@ interface IServiceNodeRewards {
     function proofOfPossessionTag() external view returns (bytes32);
     function recipientRatio() external view returns (uint256);
     function recipients(address) external view returns (uint256 rewards, uint256 claimed);
-    function removalTag() external view returns (bytes32);
+    function exitTag() external view returns (bytes32);
     function rewardTag() external view returns (bytes32);
     function serviceNodes(uint64) external view returns (ServiceNode memory);
     function serviceNodeIDs(bytes memory) external view returns (uint64);
@@ -109,14 +109,14 @@ interface IServiceNodeRewards {
         Contributor[] memory contributors
     ) external;
     function validateProofOfPossession(BN256G1.G1Point memory blsPubkey, BLSSignatureParams memory blsSignature, address caller, uint256 serviceNodePubkey) external;
-    function initiateRemoveBLSPublicKey(uint64 serviceNodeID) external;
-    function removeBLSPublicKeyWithSignature(
+    function initiateExitBLSPublicKey(uint64 serviceNodeID) external;
+    function exitBLSPublicKeyWithSignature(
         BN256G1.G1Point calldata blsPubkey,
         uint256 timestamp,
         BLSSignatureParams calldata blsSignature,
         uint64[] memory ids
     ) external;
-    function removeBLSPublicKeyAfterWaitTime(uint64 serviceNodeID) external;
+    function exitBLSPublicKeyAfterWaitTime(uint64 serviceNodeID) external;
     function liquidateBLSPublicKeyWithSignature(
         BN256G1.G1Point calldata blsPubkey,
         uint256 timestamp,

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -124,7 +124,6 @@ interface IServiceNodeRewards {
         uint64[] memory ids
     ) external;
     function seedPublicKeyList(SeedServiceNode[] calldata nodes) external;
-    function serviceNodesLength() external view returns (uint256 count);
-    function updateServiceNodesLength() external;
+    function rederiveTotalNodesAndAggregatePubkey() external;
     function start() external;
 }

--- a/contracts/interfaces/ITokenVestingStaking.sol
+++ b/contracts/interfaces/ITokenVestingStaking.sol
@@ -94,7 +94,7 @@ interface ITokenVestingStaking {
     /// their service node ID.
     ///
     /// @param serviceNodeID The ID of the service node to be removed.
-    function initiateRemoveBLSPublicKey(uint64 serviceNodeID) external;
+    function initiateExitBLSPublicKey(uint64 serviceNodeID) external;
 
     /// @notice Retrieves the unlocked balance from exited/deregistered nodes
     /// back into this investor's contract.

--- a/contracts/interfaces/ITokenVestingStaking.sol
+++ b/contracts/interfaces/ITokenVestingStaking.sol
@@ -118,15 +118,6 @@ interface ITokenVestingStaking {
     /// @param snContribBeneficiary Specify the address that will receive the
     /// rewards. This address may be set to `address(0)` to use the default
     /// behaviour. See `contributeFunds` in `IServiceNodeContribution`
-    /// @param snContribBeneficiary Specify the address that will receive the
-    /// rewards.
-    ///
-    /// This address may not be set to the zero address `address(0)`
-    /// unlike `contributeFunds` in `IServiceNodeContribution` due to the
-    /// default behaviour of assigning the beneficiary to the contributing
-    /// wallet (e.g. the investor contract) which has the effect of locking up
-    /// staking rewards and may not be intended. An explicit address must be
-    /// specified or otherwise the contract reverts.
     function contributeFunds(address snContribAddr,
                              uint256 amount,
                              address snContribBeneficiary) external;
@@ -156,9 +147,7 @@ interface ITokenVestingStaking {
     /// update. Reverts if the contract was not deployed by the factory assigned
     /// to this contract.
     /// @param snContribBeneficiary Specify the address that will receive the
-    /// rewards.
-    ///
-    /// See notes on `snContribBeneficiary` for `contributeFunds`.
+    /// rewards. See notes on `snContribBeneficiary` for `contributeFunds`.
     function updateBeneficiary(address snContribAddr, address snContribBeneficiary) external;
 
     /// @notice Allows the revoker to change the multi-contributor factory which

--- a/contracts/libraries/BN256G2.sol
+++ b/contracts/libraries/BN256G2.sol
@@ -592,9 +592,12 @@ library BN256G2 {
         uint256 y1 = 0;
         uint256 y2 = 0;
 
+        // NOTE: Mem copy bytes to `message_with_i`
         bytes memory message_with_i = new bytes(message.length + 1 /*bytes*/);
-        for (uint index = 0; index < message.length; index++) {
-            message_with_i[index] = message[index];
+        uint256 messageLength       = message.length;
+        for (uint i = 0; i < messageLength; ) {
+            message_with_i[i] = message[i];
+            unchecked { i += 1; }
         }
 
         for (uint8 increment = 0;; increment++) { // Iterate until we find a valid G2 point

--- a/contracts/libraries/Pairing.sol
+++ b/contracts/libraries/Pairing.sol
@@ -14,13 +14,14 @@ library Pairing {
         uint inputSize = elements * 6;
         uint[] memory input = new uint[](inputSize);
 
-        for (uint i = 0; i < elements; i++) {
+        for (uint i = 0; i < elements; ) {
             input[i * 6 + 0] = p1[i].X;
             input[i * 6 + 1] = p1[i].Y;
             input[i * 6 + 2] = p2[i].X[0];
             input[i * 6 + 3] = p2[i].X[1];
             input[i * 6 + 4] = p2[i].Y[0];
             input[i * 6 + 5] = p2[i].Y[1];
+            unchecked { i += 1; }
         }
 
         uint[1] memory out;

--- a/contracts/test/MockServiceNodeRewards.sol
+++ b/contracts/test/MockServiceNodeRewards.sol
@@ -70,7 +70,7 @@ contract MockServiceNodeRewards is Ownable {
         designatedToken.safeTransferFrom(msg.sender, address(this), stakingRequirement);
     }
 
-    function removeBLSPublicKeyWithSignature(
+    function exitBLSPublicKeyWithSignature(
         uint64 serviceNodeID,
         uint256,
         uint256,

--- a/contracts/test/TestnetServiceNodeRewards.sol
+++ b/contracts/test/TestnetServiceNodeRewards.sol
@@ -4,25 +4,25 @@ pragma solidity ^0.8.26;
 import "../ServiceNodeRewards.sol";
 
 contract TestnetServiceNodeRewards is ServiceNodeRewards {
-    // NOTE: Admin function to remove node by ID for stagenet debugging
-    function requestRemoveNodeBySNID(uint64[] calldata ids) external onlyOwner {
+    // NOTE: Admin function to exit node by ID for stagenet debugging
+    function requestExitNodeBySNID(uint64[] calldata ids) external onlyOwner {
         uint256 idsLength = ids.length;
         for (uint256 i = 0; i < idsLength; ) {
             uint64 serviceNodeID                        = ids[i];
             IServiceNodeRewards.ServiceNode memory node = this.serviceNodes(serviceNodeID);
             require(node.operator != address(0));
-            _initiateRemoveBLSPublicKey(serviceNodeID, node.operator);
+            _initiateExitBLSPublicKey(serviceNodeID, node.operator);
             unchecked { i += 1; }
         }
     }
 
-    function removeNodeBySNID(uint64[] calldata ids) external onlyOwner {
+    function exitNodeBySNID(uint64[] calldata ids) external onlyOwner {
         uint256 idsLength = ids.length;
         for (uint256 i = 0; i < idsLength; ) {
             uint64 serviceNodeID                        = ids[i];
             IServiceNodeRewards.ServiceNode memory node = this.serviceNodes(serviceNodeID);
             require(node.operator != address(0));
-            _removeBLSPublicKey(serviceNodeID, node.deposit);
+            _exitBLSPublicKey(serviceNodeID, node.deposit);
             unchecked { i += 1; }
         }
     }

--- a/contracts/test/TestnetServiceNodeRewards.sol
+++ b/contracts/test/TestnetServiceNodeRewards.sol
@@ -6,20 +6,24 @@ import "../ServiceNodeRewards.sol";
 contract TestnetServiceNodeRewards is ServiceNodeRewards {
     // NOTE: Admin function to remove node by ID for stagenet debugging
     function requestRemoveNodeBySNID(uint64[] calldata ids) external onlyOwner {
-        for (uint256 i = 0; i < ids.length; i++) {
-            uint64 serviceNodeID = ids[i];
+        uint256 idsLength = ids.length;
+        for (uint256 i = 0; i < idsLength; ) {
+            uint64 serviceNodeID                        = ids[i];
             IServiceNodeRewards.ServiceNode memory node = this.serviceNodes(serviceNodeID);
             require(node.operator != address(0));
             _initiateRemoveBLSPublicKey(serviceNodeID, node.operator);
+            unchecked { i += 1; }
         }
     }
 
     function removeNodeBySNID(uint64[] calldata ids) external onlyOwner {
-        for (uint256 i = 0; i < ids.length; i++) {
-            uint64 serviceNodeID = ids[i];
+        uint256 idsLength = ids.length;
+        for (uint256 i = 0; i < idsLength; ) {
+            uint64 serviceNodeID                        = ids[i];
             IServiceNodeRewards.ServiceNode memory node = this.serviceNodes(serviceNodeID);
             require(node.operator != address(0));
             _removeBLSPublicKey(serviceNodeID, node.deposit);
+            unchecked { i += 1; }
         }
     }
 }

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -147,8 +147,8 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
         rewardsContract.addBLSPublicKey(blsPubkey, blsSignature, serviceNodeParams, contributors);
     }
 
-    function initiateRemoveBLSPublicKey(uint64 serviceNodeID) external onlyRevokerIfRevokedElseBeneficiary afterStart {
-        rewardsContract.initiateRemoveBLSPublicKey(serviceNodeID);
+    function initiateExitBLSPublicKey(uint64 serviceNodeID) external onlyRevokerIfRevokedElseBeneficiary afterStart {
+        rewardsContract.initiateExitBLSPublicKey(serviceNodeID);
     }
 
     function claimRewards() external onlyRevokerIfRevokedElseBeneficiary afterStart {

--- a/scripts/attach-and-dump-sn-rewards-stats.js
+++ b/scripts/attach-and-dump-sn-rewards-stats.js
@@ -21,7 +21,7 @@ async function main() {
     console.log("Num Pubkey Aggregations For Height: " + await sn_rewards.numPubkeyAggregationsForHeight());
     console.log("Pool Share of Liquidation Ratio:    " + await sn_rewards.poolShareOfLiquidationRatio());
     console.log("Recipient Ratio:                    " + await sn_rewards.recipientRatio());
-    console.log("Removal Tag:                        " + await sn_rewards.removalTag());
+    console.log("Exit Tag:                           " + await sn_rewards.exitTag());
     console.log("Reward Tag:                         " + await sn_rewards.rewardTag());
     console.log("Staking Requirement:                " + await sn_rewards.stakingRequirement());
     console.log("Total Nodes:                        " + await sn_rewards.totalNodes());

--- a/scripts/attach-and-dump-sn-rewards-stats.js
+++ b/scripts/attach-and-dump-sn-rewards-stats.js
@@ -1,7 +1,9 @@
 const { ethers } = require('hardhat');
 async function main() {
     const sn_rewards_factory = await ethers.getContractFactory('TestnetServiceNodeRewards');
-    const sn_rewards         = await sn_rewards_factory.attach('0xb691e7C159369475D0a3d4694639ae0144c7bAB2');
+    const stagenet           = '0xb691e7C159369475D0a3d4694639ae0144c7bAB2';
+    const devnet             = '0x3433798131A72d99C5779E2B4998B17039941F7b';
+    const sn_rewards         = await sn_rewards_factory.attach(stagenet);
 
     const aggregate_pubkey = await sn_rewards.aggregatePubkey();
     console.log("Aggregate Pubkey:                   " + aggregate_pubkey[0].toString(16) + " " + aggregate_pubkey[1].toString(16));
@@ -11,12 +13,12 @@ async function main() {
     console.log("Claim Cycle:                        " + await sn_rewards.claimCycle());
     console.log("Current Claim Total:                " + await sn_rewards.currentClaimTotal());
     console.log("Current Claim Cycle:                " + await sn_rewards.currentClaimCycle());
-    console.log("Last Height Pubkey Aggregated:      " + await sn_rewards._lastHeightPubkeyWasAggregated());
+    console.log("Last Height Pubkey Aggregated:      " + await sn_rewards.lastHeightPubkeyWasAggregated());
     console.log("Liquidator Reward Ratio:            " + await sn_rewards.liquidatorRewardRatio());
     console.log("Max Contributors:                   " + await sn_rewards.maxContributors());
     console.log("Max Permitted Pubkey Aggregations:  " + await sn_rewards.maxPermittedPubkeyAggregations());
     console.log("Next Service Node ID:               " + await sn_rewards.nextServiceNodeID());
-    console.log("Num Pubkey Aggregations For Height: " + await sn_rewards._numPubkeyAggregationsForHeight());
+    console.log("Num Pubkey Aggregations For Height: " + await sn_rewards.numPubkeyAggregationsForHeight());
     console.log("Pool Share of Liquidation Ratio:    " + await sn_rewards.poolShareOfLiquidationRatio());
     console.log("Recipient Ratio:                    " + await sn_rewards.recipientRatio());
     console.log("Removal Tag:                        " + await sn_rewards.removalTag());

--- a/scripts/attach-and-dump-sn-rewards-stats.js
+++ b/scripts/attach-and-dump-sn-rewards-stats.js
@@ -22,7 +22,6 @@ async function main() {
     console.log("Removal Tag:                        " + await sn_rewards.removalTag());
     console.log("Reward Tag:                         " + await sn_rewards.rewardTag());
     console.log("Staking Requirement:                " + await sn_rewards.stakingRequirement());
-    console.log("Service Nodes Length:               " + await sn_rewards.serviceNodesLength());
     console.log("Total Nodes:                        " + await sn_rewards.totalNodes());
 
     // NOTE: Print all the Session Node IDs via 'allServiceNodeIDs' into a JS structure

--- a/scripts/deploy-local-test.js
+++ b/scripts/deploy-local-test.js
@@ -30,7 +30,9 @@ async function main() {
 
     // NOTE: Deploy the multi contribution factory
     const sn_contrib_factory_deployer = await ethers.getContractFactory("ServiceNodeContributionFactory");
-    const sn_contrib_factory          = await sn_contrib_factory_deployer.deploy(await sn_rewards.getAddress());
+    const sn_contrib_factory          = await upgrades.deployProxy(sn_contrib_factory_deployer, [
+        await sn_rewards.getAddress()
+    ]);
     await sn_contrib_factory.waitForDeployment();
 
     // NOTE: Output contract addresses

--- a/test/cpp/include/service_node_rewards/service_node_list.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_list.hpp
@@ -57,7 +57,7 @@ public:
             const std::string& contractAddress,
             const std::vector<uint64_t>& indices,
             std::optional<std::chrono::system_clock::time_point> timestamp = std::nullopt);
-    std::tuple<std::string, uint64_t, std::string> removeNodeFromIndices(uint64_t nodeID, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& indices);
+    std::tuple<std::string, uint64_t, std::string> exitNodeFromIndices(uint64_t nodeID, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& indices);
     std::string updateRewardsBalance(const std::string& address, uint64_t amount, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& service_node_ids);
 
     std::vector<uint64_t> findNonSigners(const std::vector<uint64_t>& indices);

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -53,9 +53,9 @@ public:
     Recipient           viewRecipientData(const std::string& address);
 
     ethyl::Transaction liquidateBLSPublicKeyWithSignature(const std::string& pubkey, const uint64_t timestamp, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);
-    ethyl::Transaction initiateRemoveBLSPublicKey(const uint64_t service_node_id);
-    ethyl::Transaction removeBLSPublicKeyAfterWaitTime(const uint64_t service_node_id);
-    ethyl::Transaction removeBLSPublicKeyWithSignature(const std::string& pubkey, const uint64_t timestamp, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);
+    ethyl::Transaction initiateExitBLSPublicKey(const uint64_t service_node_id);
+    ethyl::Transaction exitBLSPublicKeyAfterWaitTime(const uint64_t service_node_id);
+    ethyl::Transaction exitBLSPublicKeyWithSignature(const std::string& pubkey, const uint64_t timestamp, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);
     ethyl::Transaction updateRewardsBalance(const std::string& address, const uint64_t amount, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);
     ethyl::Transaction claimRewards();
     ethyl::Transaction claimRewards(uint64_t amount);

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -45,7 +45,7 @@ public:
 
     ContractServiceNode serviceNodes(uint64_t index);
     uint64_t            serviceNodeIDs(const bls::PublicKey& pKey);
-    uint64_t            serviceNodesLength();
+    uint64_t            totalNodes();
     uint64_t            maxPermittedPubkeyAggregations();
     std::string         designatedToken();
     std::string         aggregatePubkeyString();

--- a/test/cpp/src/service_node_list.cpp
+++ b/test/cpp/src/service_node_list.cpp
@@ -16,7 +16,7 @@ extern "C" {
 
 const std::string proofOfPossessionTag = "BLS_SIG_TRYANDINCREMENT_POP";
 const std::string rewardTag = "BLS_SIG_TRYANDINCREMENT_REWARD";
-const std::string removalTag = "BLS_SIG_TRYANDINCREMENT_REMOVE";
+const std::string exitTag = "BLS_SIG_TRYANDINCREMENT_EXIT";
 const std::string liquidateTag = "BLS_SIG_TRYANDINCREMENT_LIQUIDATE";
 const std::string hashToG2Tag = "BLS_SIG_HASH_TO_FIELD_TAG";
 
@@ -311,9 +311,9 @@ std::tuple<std::string, uint64_t, std::string> ServiceNodeList::liquidateNodeFro
     return result;
 }
 
-std::tuple<std::string, uint64_t, std::string> ServiceNodeList::removeNodeFromIndices(uint64_t nodeID, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& service_node_ids) {
+std::tuple<std::string, uint64_t, std::string> ServiceNodeList::exitNodeFromIndices(uint64_t nodeID, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& service_node_ids) {
     std::string pubkey = nodes[static_cast<size_t>(findNodeIndex(nodeID))].getPublicKeyHex();
-    std::string fullTag = buildTag(removalTag, chainID, contractAddress);
+    std::string fullTag = buildTag(exitTag, chainID, contractAddress);
     auto timestamp = to_ts(std::chrono::system_clock::now());
     std::string message = "0x" + fullTag + pubkey + ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(timestamp), ethyl::utils::PaddingDirection::LEFT);
     bls::Signature aggSig;

--- a/test/cpp/src/service_node_rewards_contract.cpp
+++ b/test/cpp/src/service_node_rewards_contract.cpp
@@ -188,9 +188,9 @@ ethyl::Transaction ServiceNodeRewardsContract::liquidateBLSPublicKeyWithSignatur
     return tx;
 }
 
-ethyl::Transaction ServiceNodeRewardsContract::removeBLSPublicKeyWithSignature(const std::string& pubkey, const uint64_t timestamp, const std::string& sig, const std::vector<uint64_t>& non_signer_indices) {
+ethyl::Transaction ServiceNodeRewardsContract::exitBLSPublicKeyWithSignature(const std::string& pubkey, const uint64_t timestamp, const std::string& sig, const std::vector<uint64_t>& non_signer_indices) {
     ethyl::Transaction tx(contractAddress, 0, 30000000);
-    std::string functionSelector = ethyl::utils::toEthFunctionSignature("removeBLSPublicKeyWithSignature((uint256,uint256),uint256,(uint256,uint256,uint256,uint256),uint64[])");
+    std::string functionSelector = ethyl::utils::toEthFunctionSignature("exitBLSPublicKeyWithSignature((uint256,uint256),uint256,(uint256,uint256,uint256,uint256),uint64[])");
     std::string timestamp_padded = ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(timestamp), ethyl::utils::PaddingDirection::LEFT);
     // 8 Params: timestamp, 2x pubkey, 4x sig, pointer to array
     std::string indices_padded = ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(8*32), ethyl::utils::PaddingDirection::LEFT);
@@ -203,17 +203,17 @@ ethyl::Transaction ServiceNodeRewardsContract::removeBLSPublicKeyWithSignature(c
     return tx;
 }
 
-ethyl::Transaction ServiceNodeRewardsContract::initiateRemoveBLSPublicKey(const uint64_t service_node_id) {
+ethyl::Transaction ServiceNodeRewardsContract::initiateExitBLSPublicKey(const uint64_t service_node_id) {
     ethyl::Transaction tx(contractAddress, 0, 3000000);
-    std::string functionSelector = ethyl::utils::toEthFunctionSignature("initiateRemoveBLSPublicKey(uint64)");
+    std::string functionSelector = ethyl::utils::toEthFunctionSignature("initiateExitBLSPublicKey(uint64)");
     std::string node_id_padded = ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(service_node_id), ethyl::utils::PaddingDirection::LEFT);
     tx.data = functionSelector + node_id_padded;
     return tx;
 }
 
-ethyl::Transaction ServiceNodeRewardsContract::removeBLSPublicKeyAfterWaitTime(const uint64_t service_node_id) {
+ethyl::Transaction ServiceNodeRewardsContract::exitBLSPublicKeyAfterWaitTime(const uint64_t service_node_id) {
     ethyl::Transaction tx(contractAddress, 0, 3000000);
-    std::string functionSelector = ethyl::utils::toEthFunctionSignature("removeBLSPublicKeyAfterWaitTime(uint64)");
+    std::string functionSelector = ethyl::utils::toEthFunctionSignature("exitBLSPublicKeyAfterWaitTime(uint64)");
     std::string node_id_padded = ethyl::utils::padTo32Bytes(ethyl::utils::decimalToHex(service_node_id), ethyl::utils::PaddingDirection::LEFT);
     tx.data = functionSelector + node_id_padded;
     return tx;

--- a/test/cpp/src/service_node_rewards_contract.cpp
+++ b/test/cpp/src/service_node_rewards_contract.cpp
@@ -125,8 +125,8 @@ uint64_t ServiceNodeRewardsContract::serviceNodeIDs(const bls::PublicKey& pKey)
     return result;
 }
 
-uint64_t ServiceNodeRewardsContract::serviceNodesLength() {
-    auto data = ethyl::utils::toEthFunctionSignature("serviceNodesLength()");
+uint64_t ServiceNodeRewardsContract::totalNodes() {
+    auto data = ethyl::utils::toEthFunctionSignature("totalNodes()");
     std::string result = provider.callReadFunction(contractAddress, data);
     return ethyl::utils::hexStringToU64(result);
 }

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -196,9 +196,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             signer.sendTransaction(tx, seckey);
         }
         REQUIRE(rewards_contract.totalNodes() == 3);
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
         const auto signers = snl.randomSigners(snl.nodes.size());
-        auto [pubkey, timestamp, sig] = snl.liquidateNodeFromIndices(service_node_to_remove, config.CHAIN_ID, contract_address, signers);
+        auto [pubkey, timestamp, sig] = snl.liquidateNodeFromIndices(service_node_to_exit, config.CHAIN_ID, contract_address, signers);
         const auto non_signers = snl.findNonSigners(signers);
         tx = rewards_contract.liquidateBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
 
@@ -211,7 +211,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
 
         std::tie(pubkey, timestamp, sig) = snl.liquidateNodeFromIndices(
-                service_node_to_remove,
+                service_node_to_exit,
                 config.CHAIN_ID,
                 contract_address,
                 signers,
@@ -222,7 +222,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
         REQUIRE(rewards_contract.totalNodes() == 2);
-        snl.deleteNode(service_node_to_remove);
+        snl.deleteNode(service_node_to_exit);
         REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
 
         verifyEVMServiceNodesAgainstCPPState(snl);
@@ -239,10 +239,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             signer.sendTransaction(tx, seckey);
         }
         REQUIRE(rewards_contract.totalNodes() == 3);
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
         const auto signers = snl.randomSigners(snl.nodes.size() - 1);
         defaultProvider.evm_increaseTime(2h);
-        const auto [pubkey, timestamp, sig] = snl.liquidateNodeFromIndices(service_node_to_remove, config.CHAIN_ID, contract_address, signers,
+        const auto [pubkey, timestamp, sig] = snl.liquidateNodeFromIndices(service_node_to_exit, config.CHAIN_ID, contract_address, signers,
                 std::chrono::system_clock::now() + 2h);
         const auto non_signers = snl.findNonSigners(signers);
         tx = rewards_contract.liquidateBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
@@ -250,7 +250,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
         REQUIRE(rewards_contract.totalNodes() == 2);
-        snl.deleteNode(service_node_to_remove);
+        snl.deleteNode(service_node_to_exit);
         REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
 
         verifyEVMServiceNodesAgainstCPPState(snl);
@@ -267,9 +267,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             signer.sendTransaction(tx, seckey);
         }
         REQUIRE(rewards_contract.totalNodes() == 3);
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
         const auto signers = snl.randomSigners(snl.nodes.size() - 2);
-        const auto [pubkey, timestamp, sig] = snl.liquidateNodeFromIndices(service_node_to_remove, config.CHAIN_ID, contract_address, signers);
+        const auto [pubkey, timestamp, sig] = snl.liquidateNodeFromIndices(service_node_to_exit, config.CHAIN_ID, contract_address, signers);
         const auto non_signers = snl.findNonSigners(signers);
         tx = rewards_contract.liquidateBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
@@ -280,7 +280,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         resetContractToSnapshot();
     }
 
-    SECTION( "Initiate remove public key with correct signer" ) {
+    SECTION( "Initiate exit public key with correct signer" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -289,8 +289,8 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             tx = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey" + std::to_string(node.service_node_id), "sig", 0);
             signer.sendTransaction(tx, seckey);
         }
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
-        tx = rewards_contract.initiateRemoveBLSPublicKey(service_node_to_remove);
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
+        tx = rewards_contract.initiateExitBLSPublicKey(service_node_to_exit);
         hash = signer.sendTransaction(tx, seckey);
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
@@ -300,7 +300,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         resetContractToSnapshot();
     }
 
-    SECTION( "Initiate remove public key with incorrect signer" ) {
+    SECTION( "Initiate exit public key with incorrect signer" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -309,8 +309,8 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             tx = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey" + std::to_string(node.service_node_id), "sig", 0);
             signer.sendTransaction(tx, seckey);
         }
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
-        tx = rewards_contract.initiateRemoveBLSPublicKey(service_node_to_remove);
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
+        tx = rewards_contract.initiateExitBLSPublicKey(service_node_to_exit);
         std::vector<unsigned char> badseckey = ethyl::utils::fromHexString(std::string(config.ADDITIONAL_PRIVATE_KEY1));
         REQUIRE_THROWS(signer.sendTransaction(tx, badseckey));
         REQUIRE(rewards_contract.totalNodes() == 3);
@@ -319,7 +319,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         resetContractToSnapshot();
     }
 
-    SECTION( "Remove public key after wait time should fail if node hasn't initiated removal" ) {
+    SECTION( "Exit public key after wait time should fail if node hasn't initiated removal" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -328,8 +328,8 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             tx = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey" + std::to_string(node.service_node_id), "sig", 0);
             signer.sendTransaction(tx, seckey);
         }
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
-        tx = rewards_contract.removeBLSPublicKeyAfterWaitTime(service_node_to_remove);
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
+        tx = rewards_contract.exitBLSPublicKeyAfterWaitTime(service_node_to_exit);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.totalNodes() == 3);
 
@@ -337,7 +337,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         resetContractToSnapshot();
     }
 
-    SECTION( "Remove public key after wait time should fail if not enough time has passed since node initiated removal" ) {
+    SECTION( "Exit public key after wait time should fail if not enough time has passed since node initiated removal" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -346,12 +346,12 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             tx = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey" + std::to_string(node.service_node_id), "sig", 0);
             signer.sendTransaction(tx, seckey);
         }
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
-        tx = rewards_contract.initiateRemoveBLSPublicKey(service_node_to_remove);
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
+        tx = rewards_contract.initiateExitBLSPublicKey(service_node_to_exit);
         hash = signer.sendTransaction(tx, seckey);
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
-        tx = rewards_contract.removeBLSPublicKeyAfterWaitTime(service_node_to_remove);
+        tx = rewards_contract.exitBLSPublicKeyAfterWaitTime(service_node_to_exit);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.totalNodes() == 3);
 
@@ -359,7 +359,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         resetContractToSnapshot();
     }
 
-    SECTION( "Remove public key after wait time should succeed if enough time has passed since node initiated removal" ) {
+    SECTION( "Exit public key after wait time should succeed if enough time has passed since node initiated removal" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -368,26 +368,26 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             tx = rewards_contract.addBLSPublicKey(pubkey, proof_of_possession, "pubkey" + std::to_string(node.service_node_id), "sig", 0);
             signer.sendTransaction(tx, seckey);
         }
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
-        tx = rewards_contract.initiateRemoveBLSPublicKey(service_node_to_remove);
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
+        tx = rewards_contract.initiateExitBLSPublicKey(service_node_to_exit);
         hash = signer.sendTransaction(tx, seckey);
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
         // Fast forward 31 days
         defaultProvider.evm_increaseTime(std::chrono::hours(31 * 24));
-        tx = rewards_contract.removeBLSPublicKeyAfterWaitTime(service_node_to_remove);
+        tx = rewards_contract.exitBLSPublicKeyAfterWaitTime(service_node_to_exit);
         hash = signer.sendTransaction(tx, seckey);
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
         REQUIRE(rewards_contract.totalNodes() == 2);
-        snl.deleteNode(service_node_to_remove);
+        snl.deleteNode(service_node_to_exit);
         REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
 
         verifyEVMServiceNodesAgainstCPPState(snl);
         resetContractToSnapshot();
     }
 
-    SECTION( "Add several public keys to the smart contract and remove one of them with a single non signer" ) {
+    SECTION( "Add several public keys to the smart contract and exit one of them with a single non signer" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -397,23 +397,23 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             signer.sendTransaction(tx, seckey);
         }
         REQUIRE(rewards_contract.totalNodes() == 3);
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
         const auto signers = snl.randomSigners(snl.nodes.size() - 1);
-        const auto [pubkey, timestamp, sig] = snl.removeNodeFromIndices(service_node_to_remove, config.CHAIN_ID, contract_address, signers);
+        const auto [pubkey, timestamp, sig] = snl.exitNodeFromIndices(service_node_to_exit, config.CHAIN_ID, contract_address, signers);
         const auto non_signers = snl.findNonSigners(signers);
-        tx = rewards_contract.removeBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
+        tx = rewards_contract.exitBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
         hash = signer.sendTransaction(tx, seckey);
         REQUIRE(hash != "");
         REQUIRE(defaultProvider.transactionSuccessful(hash));
         REQUIRE(rewards_contract.totalNodes() == 2);
-        snl.deleteNode(service_node_to_remove);
+        snl.deleteNode(service_node_to_exit);
         REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
 
         verifyEVMServiceNodesAgainstCPPState(snl);
         resetContractToSnapshot();
     }
 
-    SECTION( "Add several public keys to the smart contract and try remove one of them not enough signers" ) {
+    SECTION( "Add several public keys to the smart contract and try exit one of them not enough signers" ) {
         REQUIRE(rewards_contract.totalNodes() == 0);
         ServiceNodeList snl(3);
         for(auto& node : snl.nodes) {
@@ -423,11 +423,11 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             signer.sendTransaction(tx, seckey);
         }
         REQUIRE(rewards_contract.totalNodes() == 3);
-        const uint64_t service_node_to_remove = snl.randomServiceNodeID();
+        const uint64_t service_node_to_exit = snl.randomServiceNodeID();
         const auto signers = snl.randomSigners(snl.nodes.size() - 2);
-        const auto [pubkey, timestamp, sig] = snl.removeNodeFromIndices(service_node_to_remove, config.CHAIN_ID, contract_address, signers);
+        const auto [pubkey, timestamp, sig] = snl.exitNodeFromIndices(service_node_to_exit, config.CHAIN_ID, contract_address, signers);
         const auto non_signers = snl.findNonSigners(signers);
-        tx = rewards_contract.removeBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
+        tx = rewards_contract.exitBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.totalNodes() == 3);
         REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());

--- a/test/unit-js/ServiceNodeContributionTest.js
+++ b/test/unit-js/ServiceNodeContributionTest.js
@@ -145,7 +145,7 @@ describe("ServiceNodeContribution Contract Tests", function () {
         // NOTE: Deploy contract instances
         sentToken             = await sentTokenContractFactory.deploy("SENT Token", "SENT", 9);
         snRewards             = await snRewardsContractFactory.deploy(sentToken, STAKING_TEST_AMNT);
-        snContributionFactory = await snContributionContractFactory.deploy(snRewards);
+        snContributionFactory = await upgrades.deployProxy(snContributionContractFactory, [await snRewards.getAddress()]);
     });
 
     it("Verify staking rewards contract is set", async function () {

--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -90,19 +90,19 @@ describe("ServiceNodeRewards Contract Tests", function () {
             });
 
             it("Test initiate leave is permitted", async function () {
-                await serviceNodeRewards.connect(owner).initiateRemoveBLSPublicKey(1);
+                await serviceNodeRewards.connect(owner).initiateExitBLSPublicKey(1);
             });
 
             it("Test repeated initiate leave is not permitted before waiting", async function () {
-                await expect(serviceNodeRewards.connect(owner).initiateRemoveBLSPublicKey(1)).to.not.be.reverted;
+                await expect(serviceNodeRewards.connect(owner).initiateExitBLSPublicKey(1)).to.not.be.reverted;
                 await network.provider.send("evm_increaseTime", [(60 * 60 * 1) - 1]);
-                await expect(serviceNodeRewards.connect(owner).initiateRemoveBLSPublicKey(1)).to.be.reverted;
+                await expect(serviceNodeRewards.connect(owner).initiateExitBLSPublicKey(1)).to.be.reverted;
             });
 
             it("Test repeated initiate leave is permitted after waiting", async function () {
-                await expect(serviceNodeRewards.connect(owner).initiateRemoveBLSPublicKey(1)).to.not.be.reverted;
+                await expect(serviceNodeRewards.connect(owner).initiateExitBLSPublicKey(1)).to.not.be.reverted;
                 await network.provider.send("evm_increaseTime", [(60 * 60 * 1) - 0]);
-                await expect(serviceNodeRewards.connect(owner).initiateRemoveBLSPublicKey(1)).to.not.be.reverted;
+                await expect(serviceNodeRewards.connect(owner).initiateExitBLSPublicKey(1)).to.not.be.reverted;
             });
         });
 

--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -6541,8 +6541,6 @@ describe("ServiceNodeRewards Contract Tests", function () {
             }
 
             expect(await serviceNodeRewards.allServiceNodeIDs()).to.deep.equal([expected_ids, expected_pks]);
-            expect(await serviceNodeRewards.allServiceNodePubkeys()).to.deep.equal(expected_pks);
-
             let sn27 = await serviceNodeRewards.serviceNodes(27);
             expect(sn27.operator).to.equal(BigInt(contributors[26][0]["addr"]));
             expect(sn27.contributors.length).to.equal(4);

--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -80,11 +80,12 @@ describe("ServiceNodeRewards Contract Tests", function () {
                 ];
 
                 await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
-                expect(await serviceNodeRewards.serviceNodesLength()).to.equal(1);
+                expect(await serviceNodeRewards.totalNodes()).to.equal(1);
                 let aggregate_pubkey = await serviceNodeRewards.aggregatePubkey();
                 expect(aggregate_pubkey[0]).to.equal(seedData[0].blsPubkey.X)
                 expect(aggregate_pubkey[1]).to.equal(seedData[0].blsPubkey.Y)
                 verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
+
                 await serviceNodeRewards.start();
             });
 
@@ -153,13 +154,13 @@ describe("ServiceNodeRewards Contract Tests", function () {
 
             // NOTE: We know that the sentinel node is reserved at the 0th ID.
             // Hence the 2 service nodes we added are at ID 1 and 2.
-            expect(await serviceNodeRewards.serviceNodesLength()).to.equal(2);
+            expect(await serviceNodeRewards.totalNodes()).to.equal(2);
 
             verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
             verifySeedData(await serviceNodeRewards.serviceNodes(2), seedData[1]);
 
             // NOTE: Recalculate the aggregate pubkey
-            await serviceNodeRewards.updateAggregatePubkey();
+            await serviceNodeRewards.rederiveTotalNodesAndAggregatePubkey();
             let recalc_aggregate_pubkey = await serviceNodeRewards.aggregatePubkey();
             expect(recalc_aggregate_pubkey).to.deep.equal(expected_aggregate_pubkey);
         });
@@ -451,7 +452,7 @@ describe("ServiceNodeRewards Contract Tests", function () {
             }
 
             await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
-            expect(await serviceNodeRewards.serviceNodesLength()).to.equal(1);
+            expect(await serviceNodeRewards.totalNodes()).to.equal(1);
             verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
         });
 

--- a/test/unit-js/TestnetServiceNodeRewardsTest.js
+++ b/test/unit-js/TestnetServiceNodeRewardsTest.js
@@ -69,7 +69,7 @@ describe("TestnetServiceNodeRewards Contract Tests", function () {
         ];
 
         await serviceNodeRewards.connect(owner).seedPublicKeyList(seedData);
-        expect(await serviceNodeRewards.serviceNodesLength()).to.equal(1);
+        expect(await serviceNodeRewards.totalNodes()).to.equal(1);
         let aggregate_pubkey = await serviceNodeRewards.aggregatePubkey();
         expect(aggregate_pubkey[0]).to.equal(seedData[0].blsPubkey.X);
         expect(aggregate_pubkey[1]).to.equal(seedData[0].blsPubkey.Y);
@@ -78,7 +78,7 @@ describe("TestnetServiceNodeRewards Contract Tests", function () {
 
         await serviceNodeRewards.connect(owner).requestRemoveNodeBySNID([1])
         await serviceNodeRewards.connect(owner).removeNodeBySNID([1])
-        expect(await serviceNodeRewards.serviceNodesLength()).to.equal(0);
+        expect(await serviceNodeRewards.totalNodes()).to.equal(0);
     });
 });
 

--- a/test/unit-js/TestnetServiceNodeRewardsTest.js
+++ b/test/unit-js/TestnetServiceNodeRewardsTest.js
@@ -47,7 +47,7 @@ describe("TestnetServiceNodeRewards Contract Tests", function () {
             ]);
     });
 
-    it("Seed and test the admin removal", async function () {
+    it("Seed and test the admin exit", async function () {
         let ed25519_generator = 1n;
         const seedData = [
             {
@@ -76,8 +76,8 @@ describe("TestnetServiceNodeRewards Contract Tests", function () {
         verifySeedData(await serviceNodeRewards.serviceNodes(1), seedData[0]);
         await serviceNodeRewards.connect(owner).start();
 
-        await serviceNodeRewards.connect(owner).requestRemoveNodeBySNID([1])
-        await serviceNodeRewards.connect(owner).removeNodeBySNID([1])
+        await serviceNodeRewards.connect(owner).requestExitNodeBySNID([1])
+        await serviceNodeRewards.connect(owner).exitNodeBySNID([1])
         expect(await serviceNodeRewards.totalNodes()).to.equal(0);
     });
 });

--- a/test/unit-js/TokenVestingStaking.js
+++ b/test/unit-js/TokenVestingStaking.js
@@ -125,7 +125,7 @@ describe("TokenVestingStaking Contract Tests", function () {
         it("Should be able to unstake and claim rewards", async function () {
 
             const balanceBefore = await mockERC20.balanceOf(vestingContract);
-            await mockServiceNodeRewards.removeBLSPublicKeyWithSignature(/*serviceNodeID*/ 1,0,0,0,0,0,0,[]);
+            await mockServiceNodeRewards.exitBLSPublicKeyWithSignature(/*serviceNodeID*/ 1,0,0,0,0,0,0,[]);
 
             // TODO: The mock adds +50 $SENT everytime we claim, using mocks
             // isn't great because we're not actually testing against the real
@@ -146,7 +146,7 @@ describe("TokenVestingStaking Contract Tests", function () {
 
             const contractBalanceInitially = await mockERC20.balanceOf(vestingContract);
 
-            // NOTE: Revoke before we remove the BLS public key (e.g. stake is
+            // NOTE: Revoke before we exit the BLS public key (e.g. stake is
             // not returned yet) no funds returned (they are all staked)
             {
                 const revokerBalanceBefore = await mockERC20.balanceOf(revoker);
@@ -155,8 +155,8 @@ describe("TokenVestingStaking Contract Tests", function () {
                 expect(revokerBalanceAfter).to.equal(revokerBalanceBefore);
             }
 
-            // NOTE: Remove the key to return the stake
-            await mockServiceNodeRewards.removeBLSPublicKeyWithSignature(/*serviceNodeID*/ 1,0,0,0,0,0,0,[]);
+            // NOTE: Exit the key to return the stake
+            await mockServiceNodeRewards.exitBLSPublicKeyWithSignature(/*serviceNodeID*/ 1,0,0,0,0,0,0,[]);
 
             // NOTE: Investor can still claim the rewards because they earnt it
             // on the rewards contract.

--- a/test/unit-js/TokenVestingStaking.js
+++ b/test/unit-js/TokenVestingStaking.js
@@ -68,7 +68,8 @@ describe("TokenVestingStaking Contract Tests", function () {
 
         // Deploy ServiceNodeContributionFactory
         ServiceNodeContributionFactory = await ethers.getContractFactory("ServiceNodeContributionFactory");
-        snContribFactory = await ServiceNodeContributionFactory.deploy(mockServiceNodeRewards.getAddress());
+        snContribFactory               = await upgrades.deployProxy(ServiceNodeContributionFactory,
+                                                                    [await mockServiceNodeRewards.getAddress()]);
 
         start = await time.latest() + 5;
         end   = start + 2 * 365 * 24 * 60 * 60; // + 2 Years


### PR DESCRIPTION
- Includes Zellic audit, rebased to latest
- Make the multi-contrib factory upgradable and pausable
- Remove some helper functions that have alternatives (`allServiceNodePubkeys` replaced with `allServiceNodeIDs` and `serviceNodesLength` replaced with `rederiveTotalNodesAndAggregatePubkey`). This shaves a bunch of bytes off the contract size.
- Removes the version field in NewSNv2 which was pointless because changing any field changes the function selector hash.