### PR TITLE
Allow reuse of token contract, deploy contrib factory as upgradable proxy

### DIFF
--- a/.openzeppelin/unknown-421614.json
+++ b/.openzeppelin/unknown-421614.json
@@ -44,6 +44,16 @@
       "address": "0x4abfFB7f922767f22c7aa6524823d93FDDaB54b1",
       "txHash": "0x1077bea4621711a1a8c77e5c6c332ae62078507d3bfb240a8894679b1e24c215",
       "kind": "transparent"
+    },
+    {
+      "address": "0x6F63B91c9Ee25bFFd65EfacBF2900cdf94fa905F",
+      "txHash": "0x3447afba948498f1e93fbacaf6a2e68b2d3982b7965e7f22526d83f3a77f0402",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x66d0D4f71267b3150DafF7bD486AC5E097E7E4C6",
+      "txHash": "0x547974aeed44f40b097157f35934de67e063a266d5db847ff1219121d5a87909",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -8370,6 +8380,157 @@
           },
           "t_bytes_storage": {
             "label": "bytes"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable2Step": [
+            {
+              "contract": "Ownable2StepUpgradeable",
+              "label": "_pendingOwner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol:23",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "baa6dc43991af2850b1f6085260f51bab4a7c8cc48c525e26ff8153788bdbc17": {
+      "address": "0xb74d4DFD98C620561d9D3B3B3adBf6e5B33d2c9f",
+      "txHash": "0xacc5427899ebb0f938b1d7e93df6cd117791589226a9088e95c79cf721c2f0c1",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "stakingRewardsContract",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IServiceNodeRewards)7958",
+            "contract": "ServiceNodeContributionFactory",
+            "src": "contracts/ServiceNodeContributionFactory.sol:11"
+          },
+          {
+            "label": "deployedContracts",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ServiceNodeContributionFactory",
+            "src": "contracts/ServiceNodeContributionFactory.sol:15"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)141_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Ownable2StepStorage)13_storage": {
+            "label": "struct Ownable2StepUpgradeable.Ownable2StepStorage",
+            "members": [
+              {
+                "label": "_pendingOwner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)74_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)233_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IServiceNodeRewards)7958": {
+            "label": "contract IServiceNodeRewards",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
           }
         },
         "namespaces": {

--- a/.openzeppelin/unknown-421614.json
+++ b/.openzeppelin/unknown-421614.json
@@ -24,6 +24,26 @@
       "address": "0x75Dc11700b2D03902FCb5Ca7aFd6A859a1Fa25Cb",
       "txHash": "0xd71f9926a97da1550900ab4392ef2eb363abfec55d76b91994403726f0c9e608",
       "kind": "transparent"
+    },
+    {
+      "address": "0x0860688aAD773810d031B57f4327cD70383d31CA",
+      "txHash": "0xc654e6b0725d3def4803d8beef84c2a36b1c1b86fde5b995788818214bdc626b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xF5052C2F3aD66A30ff804E82cE5799e2f993F2Bb",
+      "txHash": "0x002cd10dab0ec202fc04b4f124b1acf67242e9907aabd2bd87fd5a9ebbb1a25b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x38cD8D3F93d591C18cf26B3Be4CB2c872aC37953",
+      "txHash": "0x9fce048e55fe057966e5145ce7f558864d65f0b967819ef0df3b0f5a358abab3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4abfFB7f922767f22c7aa6524823d93FDDaB54b1",
+      "txHash": "0x1077bea4621711a1a8c77e5c6c332ae62078507d3bfb240a8894679b1e24c215",
+      "kind": "transparent"
     }
   ],
   "impls": {

--- a/scripts/attach-and-dump-sn-rewards-stats.js
+++ b/scripts/attach-and-dump-sn-rewards-stats.js
@@ -1,9 +1,9 @@
 const { ethers } = require('hardhat');
 async function main() {
     const sn_rewards_factory = await ethers.getContractFactory('TestnetServiceNodeRewards');
-    const stagenet           = '0xb691e7C159369475D0a3d4694639ae0144c7bAB2';
-    const devnet             = '0x3433798131A72d99C5779E2B4998B17039941F7b';
-    const sn_rewards         = await sn_rewards_factory.attach(stagenet);
+    const stagenet           = '0x4abfFB7f922767f22c7aa6524823d93FDDaB54b1';
+    const devnet             = '0x75Dc11700b2D03902FCb5Ca7aFd6A859a1Fa25Cb';
+    const sn_rewards         = await sn_rewards_factory.attach(devnet);
 
     const aggregate_pubkey = await sn_rewards.aggregatePubkey();
     console.log("Aggregate Pubkey:                   " + aggregate_pubkey[0].toString(16) + " " + aggregate_pubkey[1].toString(16));

--- a/scripts/deploy-devnet.js
+++ b/scripts/deploy-devnet.js
@@ -2,7 +2,7 @@
 require("./testnet-common.js")();
 
 async function main() {
-    await deployTestnetContracts("SENT Token (devnet v3)", "DEVSENT3");
+    await deployTestnetContracts("SENT Token (devnet v3)", "DEVSENT3", /*tokenAddress*/ "");
 }
 
 main().catch((error) => {

--- a/scripts/deploy-stagenet.js
+++ b/scripts/deploy-stagenet.js
@@ -2,7 +2,8 @@
 require("./testnet-common.js")();
 
 async function main() {
-    await deployTestnetContracts("SENT Token", "SENT");
+    // NOTE: We reuse the token address of the existing $SENT contract on stagenet
+    await deployTestnetContracts("SENT Token", "SENT", /*tokenAddress*/ "0x70c1f36C9cEBCa51B9344121D284D85BE36CD6bB");
 }
 
 main().catch((error) => {

--- a/scripts/testnet-common.js
+++ b/scripts/testnet-common.js
@@ -49,8 +49,8 @@ async function deployTestnetContracts(tokenName, tokenSymbol, tokenAddress) {
     await serviceNodeRewards.waitForDeployment();
 
     snContributionContractFactory = await ethers.getContractFactory("ServiceNodeContributionFactory");
-    snContributionFactory = await snContributionContractFactory.deploy(serviceNodeRewards);
-
+    snContributionFactory         = await upgrades.deployProxy(snContributionContractFactory,
+                                                               [await serviceNodeRewards.getAddress()]);
     await snContributionFactory.waitForDeployment();
 
     rewardRatePool.setBeneficiary(serviceNodeRewards);


### PR DESCRIPTION
- The stagenet was deployed directly and not as an upgradable proxy. This meant the initialiser was not called and so the staking rewards contract was not assigned in the factory causing the contract to revert when it attempted to deploy due to trying to dereference a null staking rewards contract functionality.
- Add a parameter to allow reuse of a pre-existing token address instead of deploying a new one. This allows us to reuse the previous $SENT token on stagenet to simplify the network upgrade process.