### PR TITLE
Exit/Liquidation contract error fixes

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -190,6 +190,7 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
 
     // ERRORS
     error BLSPubkeyAlreadyExists(uint64 serviceNodeID);
+    error BLSPubkeyDoesNotExist(BN256G1.G1Point pubkey);
     error BLSPubkeyDoesNotMatch(uint64 serviceNodeID, BN256G1.G1Point pubkey);
 
     // @notice The Ed25519 public key to register as a node is already being
@@ -543,6 +544,8 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     ) external whenNotPaused whenStarted hasEnoughSigners(ids.length) {
         bytes memory pubkeyBytes = BN256G1.getKeyForG1Point(blsPubkey);
         uint64 serviceNodeID = serviceNodeIDs[pubkeyBytes];
+        if (serviceNodeID == 0)
+            revert BLSPubkeyDoesNotExist(blsPubkey);
         if (signatureTimestampHasExpired(timestamp)) {
             revert SignatureExpired(serviceNodeID, timestamp, block.timestamp);
         }
@@ -618,6 +621,8 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     ) external whenNotPaused whenStarted hasEnoughSigners(ids.length) {
         bytes memory pubkeyBytes = BN256G1.getKeyForG1Point(blsPubkey);
         uint64 serviceNodeID = serviceNodeIDs[pubkeyBytes];
+        if (serviceNodeID == 0)
+            revert BLSPubkeyDoesNotExist(blsPubkey);
         if (signatureTimestampHasExpired(timestamp)) {
             revert SignatureExpired(serviceNodeID, timestamp, block.timestamp);
         }

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -974,9 +974,9 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
             [blsSignature.sigs3, blsSignature.sigs2]
         );
 
-        BN256G1.G1Point memory aggPubkey = BN256G1.negate(blsPubkey);
-        if (!Pairing.pairing2(BN256G1.P1(), signature, aggPubkey, hashToVerify)) {
-            revert InvalidBLSSignature(aggPubkey);
+        BN256G1.G1Point memory negPubkey = BN256G1.negate(blsPubkey);
+        if (!Pairing.pairing2(BN256G1.P1(), signature, negPubkey, hashToVerify)) {
+            revert InvalidBLSSignature(blsPubkey);
         }
     }
 


### PR DESCRIPTION
Fixes two issues I encountered in writing an auto-liquidation script:
- the pubkey included in the InvalidBLSSignature error was wrong
- the error for submitting a liquidation for an already-liquidated node was misleading