### PR TITLE
Apply minimum exit time to regular exits

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -543,8 +543,11 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         uint64[] memory ids
     ) external whenNotPaused whenStarted hasEnoughSigners(ids.length) {
 
-        (uint64 serviceNodeID,) = _validateBLSExitWithSignature(
+        (uint64 serviceNodeID, ServiceNode memory node) = _validateBLSExitWithSignature(
             blsPubkey, timestamp, blsSignature, exitTag, ids);
+
+        if (node.leaveRequestTimestamp == 0)
+            revert LeaveRequestNotInitiatedYet(serviceNodeID);
 
         _exitBLSPublicKey(serviceNodeID, _serviceNodes[serviceNodeID].deposit);
     }

--- a/test/cpp/include/service_node_rewards/service_node_list.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_list.hpp
@@ -56,8 +56,16 @@ public:
             uint32_t chainID,
             const std::string& contractAddress,
             const std::vector<uint64_t>& indices,
-            std::optional<std::chrono::system_clock::time_point> timestamp = std::nullopt);
-    std::tuple<std::string, uint64_t, std::string> exitNodeFromIndices(uint64_t nodeID, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& indices);
+            std::optional<std::chrono::system_clock::time_point> timestamp = std::nullopt) {
+        return exitNodeFromIndices(nodeID, chainID, contractAddress, indices, timestamp, true);
+    }
+    std::tuple<std::string, uint64_t, std::string> exitNodeFromIndices(
+            uint64_t nodeID,
+            uint32_t chainID,
+            const std::string& contractAddress,
+            const std::vector<uint64_t>& indices,
+            std::optional<std::chrono::system_clock::time_point> timestamp = std::nullopt,
+            bool liquidate = false);
     std::string updateRewardsBalance(const std::string& address, uint64_t amount, uint32_t chainID, const std::string& contractAddress, const std::vector<uint64_t>& service_node_ids);
 
     std::vector<uint64_t> findNonSigners(const std::vector<uint64_t>& indices);

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -418,6 +418,15 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
                 signers,
                 std::chrono::system_clock::now() + 2h);
         tx = rewards_contract.exitBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
+
+        // Leave request has not been submitted
+        REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
+
+        tx = rewards_contract.initiateExitBLSPublicKey(service_node_to_exit);
+        signer.sendTransaction(tx, seckey);
+
+        // Now we can actually exit:
+        tx = rewards_contract.exitBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
         hash = signer.sendTransaction(tx, seckey);
 
         REQUIRE(hash != "");


### PR DESCRIPTION
The same minimum 2 hour limit that applies to liquidation should apply to regular exits.  See comments in https://github.com/oxen-io/oxen-core/pull/1750 for more details.

This also extracts the substantially duplicate code between the public exit and liquidate with signature functions into a private function.

Edit: + requires a leave request has been made before allowing a regular, signed exit.