### PR TITLE
Add local-devnet SN contract to avoid 2hr buffer before exits are valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ fuzz:
 deploy-local:
 	npx hardhat run scripts/deploy-local-test.js --network localhost
 
+deploy-local-devnet:
+	npx hardhat run scripts/deploy-local-devnet.js --network localhost
+
 deploy-testnet:
 	npx hardhat run scripts/deploy-devnet.js --network arbitrumSepolia
 

--- a/contracts/test/LocalDevnetServiceNodeRewards.sol
+++ b/contracts/test/LocalDevnetServiceNodeRewards.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import "../ServiceNodeRewards.sol";
+
+contract LocalDevnetServiceNodeRewards is ServiceNodeRewards {
+    function minimumExitAge() internal override pure returns (uint64 result) { result = 0; }
+}

--- a/scripts/deploy-local-devnet.js
+++ b/scripts/deploy-local-devnet.js
@@ -1,0 +1,27 @@
+const hre = require("hardhat");
+const chalk = require('chalk');
+require("./testnet-common.js")();
+
+async function main() {
+    const tokenName = "SENT Token";
+    const tokenSymbol = "SENT";
+    const SENT_UNIT = 1_000_000_000n;
+    const SUPPLY = 240_000_000n * SENT_UNIT;
+    const POOL_INITIAL = 40_000_000n * SENT_UNIT;
+    const STAKING_REQ = 120n * SENT_UNIT;
+
+    const args = {
+        SENT_UNIT,
+        SUPPLY,
+        POOL_INITIAL,
+        STAKING_REQ,
+    };
+
+    await deployTestnetContracts(tokenName, tokenSymbol, args, false, true /*local_devnet*/);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});
+

--- a/scripts/testnet-common.js
+++ b/scripts/testnet-common.js
@@ -7,7 +7,7 @@
 const hre = require("hardhat");
 const chalk = require('chalk')
 
-async function deployTestnetContracts(tokenName, tokenSymbol, args = {}, verify = true) {
+async function deployTestnetContracts(tokenName, tokenSymbol, args = {}, verify = true, local_devnet = false) {
 
     const networkName = hre.network.name;
     console.log("Deploying contracts to:", networkName);
@@ -53,7 +53,8 @@ async function deployTestnetContracts(tokenName, tokenSymbol, args = {}, verify 
     await mockERC20.transfer(rewardRatePool, POOL_INITIAL);
 
     // Deploy the ServiceNodeRewards contract
-    ServiceNodeRewardsMaster = await ethers.getContractFactory("TestnetServiceNodeRewards");
+    const serviceNodeRewardsDeployContract = local_devnet ? "LocalDevnetServiceNodeRewards" : "TestnetServiceNodeRewards";
+    ServiceNodeRewardsMaster = await ethers.getContractFactory(serviceNodeRewardsDeployContract);
     serviceNodeRewards = await upgrades.deployProxy(ServiceNodeRewardsMaster,[
         await mockERC20.getAddress(),      // token address
         await rewardRatePool.getAddress(), // foundation pool address


### PR DESCRIPTION
Allow minimum exit age to be overriden in a derived contract. I use this in the local devnet to deploy a special version of the main contract that does not have the 2hr minimum exit age. This lets us test exits in the devnet script without having to wait 2 hours or somehow manipulate the oxen-core daemons to sign a timestamp in the future.