### PR TITLE
Fix broken pool amount liquidation calculation

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -659,7 +659,7 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         uint256 liquidatorAmount = (deposit * liquidatorRewardRatio) / ratioSum;
         uint256 poolAmount = deposit * poolShareOfLiquidationRatio == 0
             ? 0
-            : (poolShareOfLiquidationRatio - 1) / ratioSum + 1;
+            : (deposit * poolShareOfLiquidationRatio - 1) / ratioSum + 1;
 
         _exitBLSPublicKey(serviceNodeID, deposit - liquidatorAmount - poolAmount);
 


### PR DESCRIPTION
Stagenet is (now) configured to 0.1% to the liquidator + 0.1% returned to the pool, but performing a liquidation results in this:

<https://sepolia.arbiscan.io/tx/0x3f2636c9a3245cd947b73695fd693062efd3e8242e4a77332b53046d14cf2b17>

> From 0x9d8aB008...A82E7be35 To 0xB0CefD61...c1d05230e For 20 SESH
> From 0x9d8aB008...A82E7be35 To 0xaAD853fE...68abFC636 For 0.000000001 SESH

i.e. 1% got transferred to the liquidator, and 1 atomic unit of SESH got transfered to the pool.

Upon investigation I encountered the code changed here, which made no sense as written.

git history shows that this was an attempt to introduce a ceiling into the division, but there's no reason I can see that a ceiling here would be any better than the implicit floor of an integer division.