### PR TITLE
Atomic liquidation ratio update; remove >0 liquidator constraint

### DIFF
--- a/test/unit-js/ServiceNodeRewardsTest.js
+++ b/test/unit-js/ServiceNodeRewardsTest.js
@@ -42,8 +42,8 @@ describe("ServiceNodeRewards Contract Tests", function () {
             staking_req,                    // testnet staking requirement
             10,                             // max contributors
             1,                              // liquidator reward ratio
-            0,                              // pool share of liquidation ratio
-            1                               // recipient ratio
+            1,                              // pool share of liquidation ratio
+            8                               // recipient ratio
             ]);
     });
 

--- a/test/unit-js/TestnetServiceNodeRewardsTest.js
+++ b/test/unit-js/TestnetServiceNodeRewardsTest.js
@@ -42,8 +42,8 @@ describe("TestnetServiceNodeRewards Contract Tests", function () {
             staking_req,                       // testnet staking requirement
             10,                                // max contributors
             1,                                 // liquidator reward ratio
-            0,                                 // pool share of liquidation ratio
-            1                                  // recipient ratio
+            1,                                 // pool share of liquidation ratio
+            8                                  // recipient ratio
             ]);
     });
 


### PR DESCRIPTION
This replaces the three liquidation ratio updating functions with a single function that updates all three values at once, so that these intertwined values get updated atomically.  Before this change, you would need three separate transactions, but in between those transactions being admitted to the chain the ratio would be set to an undesired value.

This also adds a check that the liquidator+pool ratio will never exceed 1/3 of the recipient ratio, so that it will not exceed 1/4 of the total stake because any higher and oxend is not guaranteed to be able to deduct it from the operator.

Finally, this commit *removes* the requirement that the liquidator ratio must be strictly positive, allowing it to be 0.  While it normally will be positive, from team discussions a point was raised that there may be occasions to temporarily disable the liquidation penalty, such as a blockchain bug leading to significant numbers of deregistrations during which we may want the option to temporarily disable liquidation penalties until the problem is resolved.