### PR TITLE
Revert "Require leave request before accepting exit with signature"

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -537,11 +537,8 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         uint64[] memory ids
     ) external whenNotPaused whenStarted hasEnoughSigners(ids.length) {
 
-        (uint64 serviceNodeID, ServiceNode memory node) = _validateBLSExitWithSignature(
+        (uint64 serviceNodeID,) = _validateBLSExitWithSignature(
             blsPubkey, timestamp, blsSignature, exitTag, ids);
-
-        if (node.leaveRequestTimestamp == 0)
-            revert LeaveRequestNotInitiatedYet(serviceNodeID);
 
         _exitBLSPublicKey(serviceNodeID, _serviceNodes[serviceNodeID].deposit);
     }

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -418,15 +418,6 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
                 signers,
                 std::chrono::system_clock::now() + 2h);
         tx = rewards_contract.exitBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
-
-        // Leave request has not been submitted
-        REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
-
-        tx = rewards_contract.initiateExitBLSPublicKey(service_node_to_exit);
-        signer.sendTransaction(tx, seckey);
-
-        // Now we can actually exit:
-        tx = rewards_contract.exitBLSPublicKeyWithSignature(pubkey, timestamp, sig, non_signers);
         hash = signer.sendTransaction(tx, seckey);
 
         REQUIRE(hash != "");


### PR DESCRIPTION
This reverts commit 0af72874229cc99b41a999d93f2118566efc7e0d.

We want to allow deregistered nodes to have an exit buffer without facing liquidation, and those exits go via this path without leave requests having been initiated.